### PR TITLE
Added an `html()` method to the `Dashboard` class

### DIFF
--- a/evidently/dashboard/dashboard.py
+++ b/evidently/dashboard/dashboard.py
@@ -151,6 +151,9 @@ class Dashboard:
         from IPython.display import HTML
         return HTML(self.__render(inline_template))
 
+    def html(self):
+        return self.__render(file_html_template)
+
     def save(self, filename):
         parent_dir = os.path.dirname(filename)
         if parent_dir and not os.path.exists(parent_dir):


### PR DESCRIPTION
As per the title: added an `html()` method to the `Dashboard` class to support displaying dashboards in other notebook platforms e.g. Databricks.