### PR TITLE
PR to change zero_trace on graph

### DIFF
--- a/evidently/widgets/reg_abs_perc_error_in_time_widget.py
+++ b/evidently/widgets/reg_abs_perc_error_in_time_widget.py
@@ -68,12 +68,13 @@ class RegAbsPercErrorTimeWidget(Widget):
                     x = dataset_to_plot[results['utility_columns']['date']] if results['utility_columns']['date'] else dataset_to_plot.index,
                     y = [0]*dataset_to_plot.shape[0],
                     mode = 'lines',
+                    name = 'Reference',
                     opacity=0.5,
                     marker=dict(
                         size=6,
                         color='green',
                     ),
-                    showlegend=False,
+                    showlegend=True,
                 )
 
                 abs_perc_error_time.add_trace(error_trace)

--- a/evidently/widgets/reg_error_in_time_widget.py
+++ b/evidently/widgets/reg_error_in_time_widget.py
@@ -64,12 +64,13 @@ class RegErrorTimeWidget(Widget):
                     x = dataset_to_plot[results['utility_columns']['date']] if results['utility_columns']['date'] else dataset_to_plot.index,
                     y = [0]*dataset_to_plot.shape[0],
                     mode = 'lines',
+                    name = 'Reference',
                     opacity=0.5,
                     marker=dict(
                         size=6,
                         color='green',
                     ),
-                    showlegend=False,
+                    showlegend=True,
                 )
 
                 error_in_time.add_trace(error_trace)

--- a/evidently/widgets/reg_pred_and_actual_in_time_widget.py
+++ b/evidently/widgets/reg_pred_and_actual_in_time_widget.py
@@ -74,6 +74,7 @@ class RegPredActualTimeWidget(Widget):
                     x = dataset_to_plot[results['utility_columns']['date']] if results['utility_columns']['date'] else dataset_to_plot.index,
                     y = [0]*dataset_to_plot.shape[0],
                     mode = 'lines',
+                    name = 'Reference',
                     opacity=0.5,
                     marker=dict(
                         size=6,

--- a/evidently/widgets/reg_pred_and_actual_in_time_widget.py
+++ b/evidently/widgets/reg_pred_and_actual_in_time_widget.py
@@ -80,7 +80,8 @@ class RegPredActualTimeWidget(Widget):
                         size=6,
                         color='green',
                     ),
-                    showlegend=False,
+                    showlegend=True,
+                    visible='legendonly'
                 )
 
                 pred_actual_time.add_trace(target_trace)


### PR DESCRIPTION
PR to change name of zero_trace to Reference and showlegend True in all graphs to be possible to filter out this trace.

Reg_pred_and_actual_in_time_widget.py zero_trace has showlegend True but by default it is not selected