### PR TITLE
Tests for `NumTargetDriftAnalyzer`, code simplifications and documentation

### DIFF
--- a/evidently/analyzers/num_target_drift_analyzer.py
+++ b/evidently/analyzers/num_target_drift_analyzer.py
@@ -15,7 +15,7 @@ def _compute_correlation(reference_data: pd.DataFrame, current_data: pd.DataFram
         return {}
     if not pd.api.types.is_numeric_dtype(reference_data[main_column]) or \
             not pd.api.types.is_numeric_dtype(current_data[main_column]):
-        raise ValueError
+        raise ValueError(f'Column {main_column} should only contain numerical values.')
     target_p_value = stats_fun(reference_data[main_column], current_data[main_column])
     metrics = {
         prefix + '_name': main_column,

--- a/evidently/analyzers/num_target_drift_analyzer.py
+++ b/evidently/analyzers/num_target_drift_analyzer.py
@@ -11,6 +11,8 @@ from evidently.analyzers.utils import process_columns
 
 def _compute_correlation(reference_data: pd.DataFrame, current_data: pd.DataFrame, prefix,
                          main_column, num_columns, stats_fun):
+    if main_column is None:
+        return {}
     target_p_value = stats_fun(reference_data[main_column], current_data[main_column])
     metrics = {
         prefix + '_name': main_column,
@@ -37,16 +39,13 @@ class NumTargetDriftAnalyzer(Analyzer):
 
         result['metrics'] = {}
 
-        func = options.num_target_stattest_func
-        func = ks_stat_test if func is None else func
+        func = options.num_target_stattest_func or ks_stat_test
         # target
-        if target_column is not None:
-            metrics = _compute_correlation(reference_data, current_data, 'target', target_column, num_feature_names, func)
-            result['metrics'] = dict(**result['metrics'], **metrics)
+        metrics = _compute_correlation(reference_data, current_data, 'target', target_column, num_feature_names, func)
+        result['metrics'] = dict(**result['metrics'], **metrics)
 
         # prediction
-        if prediction_column is not None:
-            metrics = _compute_correlation(reference_data, current_data, 'prediction', prediction_column, num_feature_names, func)
-            result['metrics'] = dict(**result['metrics'], **metrics)
+        metrics = _compute_correlation(reference_data, current_data, 'prediction', prediction_column, num_feature_names, func)
+        result['metrics'] = dict(**result['metrics'], **metrics)
 
         return result

--- a/evidently/analyzers/num_target_drift_analyzer.py
+++ b/evidently/analyzers/num_target_drift_analyzer.py
@@ -7,10 +7,11 @@ from evidently.analyzers.base_analyzer import Analyzer
 from evidently.options import DataDriftOptions
 from evidently.analyzers.stattests import ks_stat_test
 from evidently.analyzers.utils import process_columns
+from typing import List, Callable
 
 
-def _compute_correlation(reference_data: pd.DataFrame, current_data: pd.DataFrame, prefix,
-                         main_column, num_columns, stats_fun):
+def _compute_correlation(reference_data: pd.DataFrame, current_data: pd.DataFrame, prefix: str,
+                         main_column: str, num_columns: List[str], stats_fun: Callable):
     if main_column is None:
         return {}
     if not pd.api.types.is_numeric_dtype(reference_data[main_column]) or \
@@ -76,11 +77,10 @@ class NumTargetDriftAnalyzer(Analyzer):
                              f'are not present in columns.num_feature_names')
 
         func = options.num_target_stattest_func or ks_stat_test
-        result['metrics'] = {}
         target_metrics = _compute_correlation(reference_data, current_data, 'target',
                                               columns.utility_columns.target, columns.num_feature_names, func)
         prediction_metrics = _compute_correlation(reference_data, current_data, 'prediction',
                                                   columns.utility_columns.prediction, columns.num_feature_names, func)
-        result['metrics'] = dict(**result['metrics'], **target_metrics, **prediction_metrics)
+        result['metrics'] = dict(**target_metrics, **prediction_metrics)
 
         return result

--- a/evidently/analyzers/num_target_drift_analyzer.py
+++ b/evidently/analyzers/num_target_drift_analyzer.py
@@ -10,7 +10,7 @@ from evidently.analyzers.utils import process_columns
 
 
 class NumTargetDriftAnalyzer(Analyzer):
-    def calculate(self, reference_data: pd.DataFrame, current_data: pd.DataFrame, column_mapping):
+    def calculate(self, reference_data: pd.DataFrame, current_data: pd.DataFrame, column_mapping) -> dict:
         options = self.options_provider.get(DataDriftOptions)
         columns = process_columns(reference_data, column_mapping)
         result = columns.as_dict()

--- a/evidently/analyzers/num_target_drift_analyzer.py
+++ b/evidently/analyzers/num_target_drift_analyzer.py
@@ -71,6 +71,10 @@ class NumTargetDriftAnalyzer(Analyzer):
         columns = process_columns(reference_data, column_mapping)
         result = columns.as_dict()
 
+        if set(columns.num_feature_names) - set(current_data.columns):
+            raise ValueError(f'Some numerical features in current data {current_data.columns}'
+                             f'are not present in columns.num_feature_names')
+
         func = options.num_target_stattest_func or ks_stat_test
         result['metrics'] = {}
         target_metrics = _compute_correlation(reference_data, current_data, 'target',

--- a/evidently/analyzers/num_target_drift_analyzer.py
+++ b/evidently/analyzers/num_target_drift_analyzer.py
@@ -9,6 +9,21 @@ from evidently.analyzers.stattests import ks_stat_test
 from evidently.analyzers.utils import process_columns
 
 
+def _compute_correlation(reference_data: pd.DataFrame, current_data: pd.DataFrame, prefix,
+                         main_column, num_columns, stats_fun):
+    target_p_value = stats_fun(reference_data[main_column], current_data[main_column])
+    metrics = {
+        prefix + '_name': main_column,
+        prefix + '_type': 'num',
+        prefix + '_drift': target_p_value
+    }
+    ref_target_corr = reference_data[num_columns + [main_column]].corr()[main_column]
+    curr_target_corr = current_data[num_columns + [main_column]].corr()[main_column]
+    target_corr = {'reference': ref_target_corr.to_dict(), 'current': curr_target_corr.to_dict()}
+    metrics[prefix + '_correlations'] = target_corr
+    return metrics
+
+
 class NumTargetDriftAnalyzer(Analyzer):
     def calculate(self, reference_data: pd.DataFrame, current_data: pd.DataFrame, column_mapping) -> dict:
         options = self.options_provider.get(DataDriftOptions)
@@ -26,30 +41,12 @@ class NumTargetDriftAnalyzer(Analyzer):
         func = ks_stat_test if func is None else func
         # target
         if target_column is not None:
-            # drift
-            target_p_value = func(reference_data[target_column], current_data[target_column])
-            result['metrics']["target_name"] = target_column
-            result['metrics']["target_type"] = 'num'
-            result['metrics']["target_drift"] = target_p_value
-
-            # corr
-            ref_target_corr = reference_data[num_feature_names + [target_column]].corr()[target_column]
-            curr_target_corr = current_data[num_feature_names + [target_column]].corr()[target_column]
-            target_corr = {'reference': ref_target_corr.to_dict(), 'current': curr_target_corr.to_dict()}
-            result['metrics']['target_correlations'] = target_corr
+            metrics = _compute_correlation(reference_data, current_data, 'target', target_column, num_feature_names, func)
+            result['metrics'] = dict(**result['metrics'], **metrics)
 
         # prediction
         if prediction_column is not None:
-            # drift
-            pred_p_value = func(reference_data[prediction_column], current_data[prediction_column])
-            result['metrics']["prediction_name"] = prediction_column
-            result['metrics']["prediction_type"] = 'num'
-            result['metrics']["prediction_drift"] = pred_p_value
-
-            # corr
-            ref_pred_corr = reference_data[num_feature_names + [prediction_column]].corr()[prediction_column]
-            curr_pred_corr = current_data[num_feature_names + [prediction_column]].corr()[prediction_column]
-            prediction_corr = {'reference': ref_pred_corr.to_dict(), 'current': curr_pred_corr.to_dict()}
-            result['metrics']['prediction_correlations'] = prediction_corr
+            metrics = _compute_correlation(reference_data, current_data, 'prediction', prediction_column, num_feature_names, func)
+            result['metrics'] = dict(**result['metrics'], **metrics)
 
         return result

--- a/evidently/analyzers/stattests/ks_stattest.py
+++ b/evidently/analyzers/stattests/ks_stattest.py
@@ -5,5 +5,5 @@ import pandas as pd
 from scipy.stats import ks_2samp
 
 
-def ks_stat_test(reference_data: pd.DataFrame, current_data: pd.DataFrame):
+def ks_stat_test(reference_data: pd.Series, current_data: pd.Series):
     return ks_2samp(reference_data, current_data)[1]

--- a/evidently/analyzers/test_numerical_target_drift_analyzer.py
+++ b/evidently/analyzers/test_numerical_target_drift_analyzer.py
@@ -1,0 +1,235 @@
+from unittest import TestCase
+
+import numpy as np
+from pandas import DataFrame
+
+from evidently import ColumnMapping
+from evidently.analyzers.cat_target_drift_analyzer import CatTargetDriftAnalyzer
+from evidently.analyzers.num_target_drift_analyzer import NumTargetDriftAnalyzer
+from evidently.options import DataDriftOptions, OptionsProvider
+
+
+class TestCatTargetDriftAnalyzer(TestCase):
+
+    def setUp(self):
+        options_provider: OptionsProvider = OptionsProvider()
+        options_provider.add(DataDriftOptions(confidence=0.5))
+        self.analyzer = NumTargetDriftAnalyzer()
+        self.analyzer.options_provider = options_provider
+
+    def _assert_result_structure(self, result):
+        self.assertTrue('utility_columns' in result)
+        self.assertTrue('cat_feature_names' in result)
+        self.assertTrue('num_feature_names' in result)
+        self.assertTrue('target_names' in result)
+        self.assertTrue('metrics' in result)
+
+    def test_raises_error_when_target_non_numeric(self):
+        df1 = DataFrame({
+            'another_target': ['a'] * 10 + ['b'] * 10
+        })
+        df2 = DataFrame({
+            'another_target': ['a'] * 10 + ['b'] * 10
+        })
+
+        with self.assertRaises(ValueError):
+            self.analyzer.calculate(df1, df2, ColumnMapping(target='another_target'))
+
+    def test_different_target_column_name(self):
+        df1 = DataFrame({
+            'another_target': range(20)
+        })
+        df2 = DataFrame({
+            'another_target': range(20)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping(target='another_target'))
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'another_target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertEqual(result['metrics']['target_drift'], 1)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'another_target': 1.0})
+        self.assertEqual(correlations['current'], {'another_target': 1.0})
+
+    def test_basic_structure_no_drift(self):
+        df1 = DataFrame({
+            'target': range(20)
+        })
+        df2 = DataFrame({
+            'target': range(20)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertEqual(result['metrics']['target_drift'], 1)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    def test_basic_structure_no_drift_2(self):
+        df1 = DataFrame({
+            'target': range(20)
+        })
+        df2 = DataFrame({
+            'target': range(19, -1, -1)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        # because of ks test, target's distribution is the same, hence no drift
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertEqual(result['metrics']['target_drift'], 1)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    def test_basic_structure_drift(self):
+        df1 = DataFrame({
+            'target': range(20)
+        })
+        df2 = DataFrame({
+            'target': range(10, 30)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 0.01229, 3)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    # def test_small_sample_size(self):
+    #     df1 = DataFrame({
+    #         'target': ['a', 'b']
+    #     })
+    #     df2 = DataFrame({
+    #         'target': ['b']
+    #     })
+    #
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.386, 2)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    #
+    # def test_different_labels_1(self):
+    #     df1 = DataFrame({
+    #         'target': ['a', 'b']
+    #     })
+    #     df2 = DataFrame({
+    #         'target': ['c']
+    #     })
+    #
+    #     # FIXME: RuntimeWarning: divide by zero encountered in true_divide
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0., 2)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    #
+    # def test_different_labels_2(self):
+    #     df1 = DataFrame({
+    #         'target': ['c'] * 10
+    #     })
+    #     df2 = DataFrame({
+    #         'target': ['a', 'b'] * 10
+    #     })
+    #
+    #     # FIXME: RuntimeWarning: divide by zero encountered in true_divide
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0., 2)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    #
+    # def test_computation_of_categories_as_numbers(self):
+    #     df1 = DataFrame({
+    #         'target': [0, 1] * 10
+    #     })
+    #     df2 = DataFrame({
+    #         'target': [1] * 5
+    #     })
+    #
+    #     # FIXME: RuntimeWarning: divide by zero encountered in true_divide
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.04122, 3)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    #
+    # def test_computing_of_target_and_prediction(self):
+    #     df1 = DataFrame({
+    #         'target': ['a', 'b'] * 10,
+    #         'prediction': ['b', 'c'] * 10
+    #     })
+    #     df2 = DataFrame({
+    #         'target': ['b', 'c'] * 5,
+    #         'prediction': ['a', 'b'] * 5
+    #     })
+    #
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0., 3)
+    #     self.assertEqual(result['metrics']['prediction_name'], 'prediction')
+    #     self.assertEqual(result['metrics']['prediction_type'], 'cat')
+    #
+    # def test_computing_of_only_prediction(self):
+    #     df1 = DataFrame({
+    #         'prediction': ['b', 'c'] * 10
+    #     })
+    #     df2 = DataFrame({
+    #         'prediction': ['a', 'b'] * 5
+    #     })
+    #     # FIXME: wtf: RuntimeWarning: divide by zero encountered in true_divide ?
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self.assertAlmostEqual(result['metrics']['prediction_drift'], 0., 3)
+    #     self.assertTrue('utility_columns' in result)
+    #     self.assertTrue('cat_feature_names' in result)
+    #     self.assertTrue('num_feature_names' in result)
+    #     self.assertTrue('metrics' in result)
+    #     self.assertEqual(result['metrics']['prediction_name'], 'prediction')
+    #     self.assertEqual(result['metrics']['prediction_type'], 'cat')
+    #
+    # def test_computing_with_nans(self):
+    #     df1 = DataFrame({
+    #         'target': ['a'] * 10 + ['b'] * 10 + [np.nan] * 2 + [np.inf] * 2,
+    #         'prediction': ['a'] * 10 + ['b'] * 10 + [np.nan] * 2 + [np.inf] * 2
+    #     })
+    #     df2 = DataFrame({
+    #         'target': ['a'] * 3 + ['b'] * 7 + [np.nan] * 2,
+    #         'prediction': ['a'] * 3 + ['b'] * 7 + [np.nan] * 2
+    #     })
+    #
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.29736, 4)
+    #     self.assertAlmostEqual(result['metrics']['prediction_drift'], 0.29736, 4)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    #
+    #     df3 = DataFrame({
+    #         'target': ['a'] * 3 + ['b'] * 7 + [np.nan] * 20,
+    #         'prediction': ['a'] * 3 + ['b'] * 7 + [np.nan] * 20
+    #     })
+    #     result = self.analyzer.calculate(df1, df3, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.29736, 4)
+    #     self.assertAlmostEqual(result['metrics']['prediction_drift'], 0.29736, 4)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    #
+    # def test_computing_uses_a_custom_function(self):
+    #     df1 = DataFrame({
+    #         'target': ['a'] * 10 + ['b'] * 10
+    #     })
+    #     df2 = DataFrame({
+    #         'target': ['a'] * 6 + ['b'] * 15
+    #     })
+    #
+    #     options = DataDriftOptions()
+    #     options.cat_target_stattest_func = lambda x, y: np.pi
+    #     self.analyzer.options_provider.add(options)
+    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
+    #     self._assert_result_structure(result)
+    #     self.assertAlmostEqual(result['metrics']['target_drift'], np.pi, 4)
+    #     self.assertEqual(result['metrics']['target_name'], 'target')

--- a/evidently/analyzers/test_numerical_target_drift_analyzer.py
+++ b/evidently/analyzers/test_numerical_target_drift_analyzer.py
@@ -52,7 +52,7 @@ def test_different_target_column_name(analyzer):
     assert result['metrics']['target_drift'] == 1
     correlations = result['metrics']['target_correlations']
     assert correlations['reference'] == {'another_target': 1.0}
-    assert correlations['current'], {'another_target': 1.0}
+    assert correlations['current'] == {'another_target': 1.0}
 
 
 def test_different_prediction_column_name(analyzer):

--- a/evidently/analyzers/test_numerical_target_drift_analyzer.py
+++ b/evidently/analyzers/test_numerical_target_drift_analyzer.py
@@ -4,7 +4,6 @@ import numpy as np
 from pandas import DataFrame
 
 from evidently import ColumnMapping
-from evidently.analyzers.cat_target_drift_analyzer import CatTargetDriftAnalyzer
 from evidently.analyzers.num_target_drift_analyzer import NumTargetDriftAnalyzer
 from evidently.options import DataDriftOptions, OptionsProvider
 
@@ -284,14 +283,7 @@ class TestCatTargetDriftAnalyzer(TestCase):
             'target': range(10)
         })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 1., 4)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
+        self.analyzer.calculate(df1, df2, ColumnMapping())
 
     def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing_2(self):
         df1 = DataFrame({
@@ -305,11 +297,4 @@ class TestCatTargetDriftAnalyzer(TestCase):
             'num_1': range(0, -10, -1),
         })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 1., 4)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
+        self.analyzer.calculate(df1, df2, ColumnMapping())

--- a/evidently/analyzers/test_numerical_target_drift_analyzer.py
+++ b/evidently/analyzers/test_numerical_target_drift_analyzer.py
@@ -283,7 +283,8 @@ class TestCatTargetDriftAnalyzer(TestCase):
             'target': range(10)
         })
 
-        self.analyzer.calculate(df1, df2, ColumnMapping())
+        with self.assertRaises(ValueError):
+            self.analyzer.calculate(df1, df2, ColumnMapping())
 
     def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing_2(self):
         df1 = DataFrame({
@@ -297,4 +298,5 @@ class TestCatTargetDriftAnalyzer(TestCase):
             'num_1': range(0, -10, -1),
         })
 
-        self.analyzer.calculate(df1, df2, ColumnMapping())
+        with self.assertRaises(ValueError):
+            self.analyzer.calculate(df1, df2, ColumnMapping())

--- a/evidently/analyzers/test_numerical_target_drift_analyzer.py
+++ b/evidently/analyzers/test_numerical_target_drift_analyzer.py
@@ -1,302 +1,319 @@
-from unittest import TestCase
-
 import numpy as np
+import pytest
 from pandas import DataFrame
+from pytest import approx
 
 from evidently import ColumnMapping
 from evidently.analyzers.num_target_drift_analyzer import NumTargetDriftAnalyzer
 from evidently.options import DataDriftOptions, OptionsProvider
 
 
-class TestCatTargetDriftAnalyzer(TestCase):
+@pytest.fixture
+def analyzer():
+    options_provider: OptionsProvider = OptionsProvider()
+    options_provider.add(DataDriftOptions(confidence=0.5))
+    analyzer = NumTargetDriftAnalyzer()
+    analyzer.options_provider = options_provider
+    return analyzer
 
-    def setUp(self):
-        options_provider: OptionsProvider = OptionsProvider()
-        options_provider.add(DataDriftOptions(confidence=0.5))
-        self.analyzer = NumTargetDriftAnalyzer()
-        self.analyzer.options_provider = options_provider
 
-    def _assert_result_structure(self, result):
-        self.assertTrue('utility_columns' in result)
-        self.assertTrue('cat_feature_names' in result)
-        self.assertTrue('num_feature_names' in result)
-        self.assertTrue('target_names' in result)
-        self.assertTrue('metrics' in result)
+def _assert_result_structure(result):
+    assert 'utility_columns' in result
+    assert 'cat_feature_names' in result
+    assert 'num_feature_names' in result
+    assert 'target_names' in result
+    assert 'metrics' in result
 
-    def test_raises_error_when_target_non_numeric(self):
-        df1 = DataFrame({
-            'another_target': ['a'] * 10 + ['b'] * 10
-        })
-        df2 = DataFrame({
-            'another_target': ['a'] * 10 + ['b'] * 10
-        })
 
-        with self.assertRaises(ValueError):
-            self.analyzer.calculate(df1, df2, ColumnMapping(target='another_target'))
+def test_raises_error_when_target_non_numeric(analyzer):
+    df1 = DataFrame({
+        'another_target': ['a'] * 10 + ['b'] * 10
+    })
+    df2 = DataFrame({
+        'another_target': ['a'] * 10 + ['b'] * 10
+    })
 
-    def test_different_target_column_name(self):
-        df1 = DataFrame({
-            'another_target': range(20)
-        })
-        df2 = DataFrame({
-            'another_target': range(20)
-        })
+    with pytest.raises(ValueError):
+        analyzer.calculate(df1, df2, ColumnMapping(target='another_target'))
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping(target='another_target'))
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'another_target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertEqual(result['metrics']['target_drift'], 1)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'another_target': 1.0})
-        self.assertEqual(correlations['current'], {'another_target': 1.0})
 
-    def test_different_prediction_column_name(self):
-        df1 = DataFrame({
-            'another_prediction': range(20)
-        })
-        df2 = DataFrame({
-            'another_prediction': range(20)
-        })
+def test_different_target_column_name(analyzer):
+    df1 = DataFrame({
+        'another_target': range(20)
+    })
+    df2 = DataFrame({
+        'another_target': range(20)
+    })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping(prediction='another_prediction'))
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['prediction_name'], 'another_prediction')
-        self.assertEqual(result['metrics']['prediction_type'], 'num')
-        self.assertEqual(result['metrics']['prediction_drift'], 1)
-        correlations = result['metrics']['prediction_correlations']
-        self.assertEqual(correlations['reference'], {'another_prediction': 1.0})
-        self.assertEqual(correlations['current'], {'another_prediction': 1.0})
+    result = analyzer.calculate(df1, df2, ColumnMapping(target='another_target'))
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'another_target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == 1
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'another_target': 1.0}
+    assert correlations['current'], {'another_target': 1.0}
 
-    def test_basic_structure_no_drift(self):
-        df1 = DataFrame({
-            'target': range(20)
-        })
-        df2 = DataFrame({
-            'target': range(20)
-        })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertEqual(result['metrics']['target_drift'], 1)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
+def test_different_prediction_column_name(analyzer):
+    df1 = DataFrame({
+        'another_prediction': range(20)
+    })
+    df2 = DataFrame({
+        'another_prediction': range(20)
+    })
 
-    def test_basic_structure_no_drift_2(self):
-        df1 = DataFrame({
-            'target': range(20)
-        })
-        df2 = DataFrame({
-            'target': range(19, -1, -1)
-        })
+    result = analyzer.calculate(df1, df2, ColumnMapping(prediction='another_prediction'))
+    _assert_result_structure(result)
+    assert result['metrics']['prediction_name'] == 'another_prediction'
+    assert result['metrics']['prediction_type'] == 'num'
+    assert result['metrics']['prediction_drift'] == 1
+    correlations = result['metrics']['prediction_correlations']
+    assert correlations['reference'] == {'another_prediction': 1.0}
+    assert correlations['current'] == {'another_prediction': 1.0}
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        # because of ks test, target's distribution is the same, hence no drift
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertEqual(result['metrics']['target_drift'], 1)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
 
-    def test_basic_structure_drift(self):
-        df1 = DataFrame({
-            'target': range(20)
-        })
-        df2 = DataFrame({
-            'target': range(10, 30)
-        })
+def test_basic_structure_no_drift(analyzer):
+    df1 = DataFrame({
+        'target': range(20)
+    })
+    df2 = DataFrame({
+        'target': range(20)
+    })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 0.01229, 3)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == 1
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert correlations['current'] == {'target': 1.0}
 
-    def test_small_sample_size_1(self):
-        df1 = DataFrame({
-            'target': [0]
-        })
-        df2 = DataFrame({
-            'target': [10]
-        })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 1, 3)
-        correlations = result['metrics']['target_correlations']
-        self.assertTrue(np.isnan(correlations['reference']['target']))
-        self.assertTrue(np.isnan(correlations['current']['target']))
+def test_basic_structure_no_drift_2(analyzer):
+    df1 = DataFrame({
+        'target': range(20)
+    })
+    df2 = DataFrame({
+        'target': range(19, -1, -1)
+    })
 
-    def test_small_sample_size_2(self):
-        df1 = DataFrame({
-            'target': [0]
-        })
-        df2 = DataFrame({
-            'target': range(10)
-        })
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    # because of ks test, target's distribution is the same, hence no drift
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == 1
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert correlations['current'] == {'target': 1.0}
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 0.3636, 3)
-        correlations = result['metrics']['target_correlations']
-        self.assertTrue(np.isnan(correlations['reference']['target']))
-        self.assertEqual(correlations['current'], {'target': 1.0})
 
-    def test_small_sample_size_3(self):
-        df1 = DataFrame({
-            'target': range(10)
-        })
-        df2 = DataFrame({
-            'target': [10]
-        })
+def test_basic_structure_drift(analyzer):
+    df1 = DataFrame({
+        'target': range(20)
+    })
+    df2 = DataFrame({
+        'target': range(10, 30)
+    })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 0.1818, 3)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertTrue(np.isnan(correlations['current']['target']))
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(0.01229, 1e-3)
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert correlations['current'] == {'target': 1.0}
 
-    def test_computing_of_target_and_prediction(self):
-        df1 = DataFrame({
-            'target': range(10),
-            'prediction': range(1, 11)
-        })
-        df2 = DataFrame({
-            'target': range(5, 15),
-            'prediction': range(2, 12)
-        })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertEqual(result['metrics']['prediction_name'], 'prediction')
-        self.assertEqual(result['metrics']['prediction_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 0.16782, 3)
-        self.assertAlmostEqual(result['metrics']['prediction_drift'], 1, 3)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
-        correlations = result['metrics']['prediction_correlations']
-        self.assertEqual(correlations['reference'], {'prediction': 1.0})
-        self.assertEqual(correlations['current'], {'prediction': 1.0})
+def test_small_sample_size_1(analyzer):
+    df1 = DataFrame({
+        'target': [0]
+    })
+    df2 = DataFrame({
+        'target': [10]
+    })
 
-    def test_computing_of_only_prediction(self):
-        df1 = DataFrame({
-            'prediction': range(1, 11)
-        })
-        df2 = DataFrame({
-            'prediction': range(3, 13)
-        })
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == 1.
+    correlations = result['metrics']['target_correlations']
+    assert np.isnan(correlations['reference']['target'])
+    assert np.isnan(correlations['current']['target'])
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['prediction_name'], 'prediction')
-        self.assertEqual(result['metrics']['prediction_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['prediction_drift'], 0.99445, 3)
-        correlations = result['metrics']['prediction_correlations']
-        self.assertEqual(correlations['reference'], {'prediction': 1.0})
-        self.assertEqual(correlations['current'], {'prediction': 1.0})
 
-    def test_computing_with_nans(self):
-        df1 = DataFrame({
-            'target': list(range(20)) + [np.nan, np.inf]
-        })
-        df2 = DataFrame({
-            'target': [np.nan, np.inf] + list(range(10, 30))
-        })
+def test_small_sample_size_2(analyzer):
+    df1 = DataFrame({
+        'target': [0]
+    })
+    df2 = DataFrame({
+        'target': range(10)
+    })
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 0.02004, 3)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(0.3636, abs=1e-3)
+    correlations = result['metrics']['target_correlations']
+    assert np.isnan(correlations['reference']['target'])
+    assert correlations['current'] == {'target': 1.0}
 
-    def test_computing_uses_a_custom_function(self):
-        df1 = DataFrame({
-            'target': range(20)
-        })
-        df2 = DataFrame({
-            'target': range(10)
-        })
 
-        options = DataDriftOptions(num_target_stattest_func=lambda x, y: np.pi)
-        self.analyzer.options_provider.add(options)
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], np.pi, 4)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'target': 1.0})
-        self.assertEqual(correlations['current'], {'target': 1.0})
+def test_small_sample_size_3(analyzer):
+    df1 = DataFrame({
+        'target': range(10)
+    })
+    df2 = DataFrame({
+        'target': [10]
+    })
 
-    def test_computing_of_correlations_between_columns(self):
-        df1 = DataFrame({
-            'target': range(20),
-            'num_1': range(0, -20, -1),
-            'num_2': range(10, -10, -1),
-            'cat_1': ['a'] * 20
-        })
-        df2 = DataFrame({
-            'target': range(10),
-            'num_1': range(0, -10, -1),
-            'num_2': range(10, 0, -1),
-            'cat_1': ['b'] * 10
-        })
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(0.1818, abs=1e-3)
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert np.isnan(correlations['current']['target'])
 
-        result = self.analyzer.calculate(df1, df2, ColumnMapping())
-        self._assert_result_structure(result)
-        self.assertEqual(result['metrics']['target_name'], 'target')
-        self.assertEqual(result['metrics']['target_type'], 'num')
-        self.assertAlmostEqual(result['metrics']['target_drift'], 0.06228, 4)
-        correlations = result['metrics']['target_correlations']
-        self.assertEqual(correlations['reference'], {'num_1': -1.0, 'num_2': -1.0, 'target': 1.0})
-        self.assertEqual(correlations['current'], {'num_1': -1.0, 'num_2': -1.0, 'target': 1.0})
 
-    def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing(self):
-        df1 = DataFrame({
-            'target': range(20),
-            'num_1': range(0, -20, -1),
-            'num_2': range(10, -10, -1),
-            'cat_1': ['a'] * 20
-        })
-        df2 = DataFrame({
-            'target': range(10)
-        })
+def test_computing_of_target_and_prediction(analyzer):
+    df1 = DataFrame({
+        'target': range(10),
+        'prediction': range(1, 11)
+    })
+    df2 = DataFrame({
+        'target': range(5, 15),
+        'prediction': range(2, 12)
+    })
 
-        with self.assertRaises(ValueError):
-            self.analyzer.calculate(df1, df2, ColumnMapping())
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['prediction_name'] == 'prediction'
+    assert result['metrics']['prediction_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(0.16782, abs=1e-3)
+    assert result['metrics']['prediction_drift'] == 1.
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert correlations['current'] == {'target': 1.0}
+    correlations = result['metrics']['prediction_correlations']
+    assert correlations['reference'] == {'prediction': 1.0}
+    assert correlations['current'] == {'prediction': 1.0}
 
-    def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing_2(self):
-        df1 = DataFrame({
-            'prediction': range(20),
-            'num_1': range(0, -20, -1),
-            'num_2': range(10, -10, -1),
-            'cat_1': ['a'] * 20
-        })
-        df2 = DataFrame({
-            'prediction': range(10),
-            'num_1': range(0, -10, -1),
-        })
 
-        with self.assertRaises(ValueError):
-            self.analyzer.calculate(df1, df2, ColumnMapping())
+def test_computing_of_only_prediction(analyzer):
+    df1 = DataFrame({
+        'prediction': range(1, 11)
+    })
+    df2 = DataFrame({
+        'prediction': range(3, 13)
+    })
+
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['prediction_name'] == 'prediction'
+    assert result['metrics']['prediction_type'] == 'num'
+    assert result['metrics']['prediction_drift'] == approx(0.99445, abs=1e-3)
+    correlations = result['metrics']['prediction_correlations']
+    assert correlations['reference'] == {'prediction': 1.0}
+    assert correlations['current'] == {'prediction': 1.0}
+
+
+def test_computing_with_nans(analyzer):
+    df1 = DataFrame({
+        'target': list(range(20)) + [np.nan, np.inf]
+    })
+    df2 = DataFrame({
+        'target': [np.nan, np.inf] + list(range(10, 30))
+    })
+
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(0.02004, abs=1e-3)
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert correlations['current'] == {'target': 1.0}
+
+
+def test_computing_uses_a_custom_function(analyzer):
+    df1 = DataFrame({
+        'target': range(20)
+    })
+    df2 = DataFrame({
+        'target': range(10)
+    })
+
+    options = DataDriftOptions(num_target_stattest_func=lambda x, y: np.pi)
+    analyzer.options_provider.add(options)
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(np.pi, abs=1e-4)
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'target': 1.0}
+    assert correlations['current'] == {'target': 1.0}
+
+
+def test_computing_of_correlations_between_columns(analyzer):
+    df1 = DataFrame({
+        'target': range(20),
+        'num_1': range(0, -20, -1),
+        'num_2': range(10, -10, -1),
+        'cat_1': ['a'] * 20
+    })
+    df2 = DataFrame({
+        'target': range(10),
+        'num_1': range(0, -10, -1),
+        'num_2': range(10, 0, -1),
+        'cat_1': ['b'] * 10
+    })
+
+    result = analyzer.calculate(df1, df2, ColumnMapping())
+    _assert_result_structure(result)
+    assert result['metrics']['target_name'] == 'target'
+    assert result['metrics']['target_type'] == 'num'
+    assert result['metrics']['target_drift'] == approx(0.06228, abs=1e-4)
+    correlations = result['metrics']['target_correlations']
+    assert correlations['reference'] == {'num_1': -1.0, 'num_2': -1.0, 'target': 1.0}
+    assert correlations['current'] == {'num_1': -1.0, 'num_2': -1.0, 'target': 1.0}
+
+
+def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing(analyzer):
+    df1 = DataFrame({
+        'target': range(20),
+        'num_1': range(0, -20, -1),
+        'num_2': range(10, -10, -1),
+        'cat_1': ['a'] * 20
+    })
+    df2 = DataFrame({
+        'target': range(10)
+    })
+
+    with pytest.raises(ValueError):
+        analyzer.calculate(df1, df2, ColumnMapping())
+
+
+def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing_2(analyzer):
+    df1 = DataFrame({
+        'prediction': range(20),
+        'num_1': range(0, -20, -1),
+        'num_2': range(10, -10, -1),
+        'cat_1': ['a'] * 20
+    })
+    df2 = DataFrame({
+        'prediction': range(10),
+        'num_1': range(0, -10, -1),
+    })
+
+    with pytest.raises(ValueError):
+        analyzer.calculate(df1, df2, ColumnMapping())

--- a/evidently/analyzers/test_numerical_target_drift_analyzer.py
+++ b/evidently/analyzers/test_numerical_target_drift_analyzer.py
@@ -52,6 +52,23 @@ class TestCatTargetDriftAnalyzer(TestCase):
         self.assertEqual(correlations['reference'], {'another_target': 1.0})
         self.assertEqual(correlations['current'], {'another_target': 1.0})
 
+    def test_different_prediction_column_name(self):
+        df1 = DataFrame({
+            'another_prediction': range(20)
+        })
+        df2 = DataFrame({
+            'another_prediction': range(20)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping(prediction='another_prediction'))
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['prediction_name'], 'another_prediction')
+        self.assertEqual(result['metrics']['prediction_type'], 'num')
+        self.assertEqual(result['metrics']['prediction_drift'], 1)
+        correlations = result['metrics']['prediction_correlations']
+        self.assertEqual(correlations['reference'], {'another_prediction': 1.0})
+        self.assertEqual(correlations['current'], {'another_prediction': 1.0})
+
     def test_basic_structure_no_drift(self):
         df1 = DataFrame({
             'target': range(20)
@@ -104,132 +121,195 @@ class TestCatTargetDriftAnalyzer(TestCase):
         self.assertEqual(correlations['reference'], {'target': 1.0})
         self.assertEqual(correlations['current'], {'target': 1.0})
 
-    # def test_small_sample_size(self):
-    #     df1 = DataFrame({
-    #         'target': ['a', 'b']
-    #     })
-    #     df2 = DataFrame({
-    #         'target': ['b']
-    #     })
-    #
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.386, 2)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
-    #
-    # def test_different_labels_1(self):
-    #     df1 = DataFrame({
-    #         'target': ['a', 'b']
-    #     })
-    #     df2 = DataFrame({
-    #         'target': ['c']
-    #     })
-    #
-    #     # FIXME: RuntimeWarning: divide by zero encountered in true_divide
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0., 2)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
-    #
-    # def test_different_labels_2(self):
-    #     df1 = DataFrame({
-    #         'target': ['c'] * 10
-    #     })
-    #     df2 = DataFrame({
-    #         'target': ['a', 'b'] * 10
-    #     })
-    #
-    #     # FIXME: RuntimeWarning: divide by zero encountered in true_divide
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0., 2)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
-    #
-    # def test_computation_of_categories_as_numbers(self):
-    #     df1 = DataFrame({
-    #         'target': [0, 1] * 10
-    #     })
-    #     df2 = DataFrame({
-    #         'target': [1] * 5
-    #     })
-    #
-    #     # FIXME: RuntimeWarning: divide by zero encountered in true_divide
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.04122, 3)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
-    #
-    # def test_computing_of_target_and_prediction(self):
-    #     df1 = DataFrame({
-    #         'target': ['a', 'b'] * 10,
-    #         'prediction': ['b', 'c'] * 10
-    #     })
-    #     df2 = DataFrame({
-    #         'target': ['b', 'c'] * 5,
-    #         'prediction': ['a', 'b'] * 5
-    #     })
-    #
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0., 3)
-    #     self.assertEqual(result['metrics']['prediction_name'], 'prediction')
-    #     self.assertEqual(result['metrics']['prediction_type'], 'cat')
-    #
-    # def test_computing_of_only_prediction(self):
-    #     df1 = DataFrame({
-    #         'prediction': ['b', 'c'] * 10
-    #     })
-    #     df2 = DataFrame({
-    #         'prediction': ['a', 'b'] * 5
-    #     })
-    #     # FIXME: wtf: RuntimeWarning: divide by zero encountered in true_divide ?
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self.assertAlmostEqual(result['metrics']['prediction_drift'], 0., 3)
-    #     self.assertTrue('utility_columns' in result)
-    #     self.assertTrue('cat_feature_names' in result)
-    #     self.assertTrue('num_feature_names' in result)
-    #     self.assertTrue('metrics' in result)
-    #     self.assertEqual(result['metrics']['prediction_name'], 'prediction')
-    #     self.assertEqual(result['metrics']['prediction_type'], 'cat')
-    #
-    # def test_computing_with_nans(self):
-    #     df1 = DataFrame({
-    #         'target': ['a'] * 10 + ['b'] * 10 + [np.nan] * 2 + [np.inf] * 2,
-    #         'prediction': ['a'] * 10 + ['b'] * 10 + [np.nan] * 2 + [np.inf] * 2
-    #     })
-    #     df2 = DataFrame({
-    #         'target': ['a'] * 3 + ['b'] * 7 + [np.nan] * 2,
-    #         'prediction': ['a'] * 3 + ['b'] * 7 + [np.nan] * 2
-    #     })
-    #
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.29736, 4)
-    #     self.assertAlmostEqual(result['metrics']['prediction_drift'], 0.29736, 4)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
-    #
-    #     df3 = DataFrame({
-    #         'target': ['a'] * 3 + ['b'] * 7 + [np.nan] * 20,
-    #         'prediction': ['a'] * 3 + ['b'] * 7 + [np.nan] * 20
-    #     })
-    #     result = self.analyzer.calculate(df1, df3, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], 0.29736, 4)
-    #     self.assertAlmostEqual(result['metrics']['prediction_drift'], 0.29736, 4)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
-    #
-    # def test_computing_uses_a_custom_function(self):
-    #     df1 = DataFrame({
-    #         'target': ['a'] * 10 + ['b'] * 10
-    #     })
-    #     df2 = DataFrame({
-    #         'target': ['a'] * 6 + ['b'] * 15
-    #     })
-    #
-    #     options = DataDriftOptions()
-    #     options.cat_target_stattest_func = lambda x, y: np.pi
-    #     self.analyzer.options_provider.add(options)
-    #     result = self.analyzer.calculate(df1, df2, ColumnMapping())
-    #     self._assert_result_structure(result)
-    #     self.assertAlmostEqual(result['metrics']['target_drift'], np.pi, 4)
-    #     self.assertEqual(result['metrics']['target_name'], 'target')
+    def test_small_sample_size_1(self):
+        df1 = DataFrame({
+            'target': [0]
+        })
+        df2 = DataFrame({
+            'target': [10]
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 1, 3)
+        correlations = result['metrics']['target_correlations']
+        self.assertTrue(np.isnan(correlations['reference']['target']))
+        self.assertTrue(np.isnan(correlations['current']['target']))
+
+    def test_small_sample_size_2(self):
+        df1 = DataFrame({
+            'target': [0]
+        })
+        df2 = DataFrame({
+            'target': range(10)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 0.3636, 3)
+        correlations = result['metrics']['target_correlations']
+        self.assertTrue(np.isnan(correlations['reference']['target']))
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    def test_small_sample_size_3(self):
+        df1 = DataFrame({
+            'target': range(10)
+        })
+        df2 = DataFrame({
+            'target': [10]
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 0.1818, 3)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertTrue(np.isnan(correlations['current']['target']))
+
+    def test_computing_of_target_and_prediction(self):
+        df1 = DataFrame({
+            'target': range(10),
+            'prediction': range(1, 11)
+        })
+        df2 = DataFrame({
+            'target': range(5, 15),
+            'prediction': range(2, 12)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertEqual(result['metrics']['prediction_name'], 'prediction')
+        self.assertEqual(result['metrics']['prediction_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 0.16782, 3)
+        self.assertAlmostEqual(result['metrics']['prediction_drift'], 1, 3)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+        correlations = result['metrics']['prediction_correlations']
+        self.assertEqual(correlations['reference'], {'prediction': 1.0})
+        self.assertEqual(correlations['current'], {'prediction': 1.0})
+
+    def test_computing_of_only_prediction(self):
+        df1 = DataFrame({
+            'prediction': range(1, 11)
+        })
+        df2 = DataFrame({
+            'prediction': range(3, 13)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['prediction_name'], 'prediction')
+        self.assertEqual(result['metrics']['prediction_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['prediction_drift'], 0.99445, 3)
+        correlations = result['metrics']['prediction_correlations']
+        self.assertEqual(correlations['reference'], {'prediction': 1.0})
+        self.assertEqual(correlations['current'], {'prediction': 1.0})
+
+    def test_computing_with_nans(self):
+        df1 = DataFrame({
+            'target': list(range(20)) + [np.nan, np.inf]
+        })
+        df2 = DataFrame({
+            'target': [np.nan, np.inf] + list(range(10, 30))
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 0.02004, 3)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    def test_computing_uses_a_custom_function(self):
+        df1 = DataFrame({
+            'target': range(20)
+        })
+        df2 = DataFrame({
+            'target': range(10)
+        })
+
+        options = DataDriftOptions(num_target_stattest_func=lambda x, y: np.pi)
+        self.analyzer.options_provider.add(options)
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], np.pi, 4)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    def test_computing_of_correlations_between_columns(self):
+        df1 = DataFrame({
+            'target': range(20),
+            'num_1': range(0, -20, -1),
+            'num_2': range(10, -10, -1),
+            'cat_1': ['a'] * 20
+        })
+        df2 = DataFrame({
+            'target': range(10),
+            'num_1': range(0, -10, -1),
+            'num_2': range(10, 0, -1),
+            'cat_1': ['b'] * 10
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 0.06228, 4)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'num_1': -1.0, 'num_2': -1.0, 'target': 1.0})
+        self.assertEqual(correlations['current'], {'num_1': -1.0, 'num_2': -1.0, 'target': 1.0})
+
+    def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing(self):
+        df1 = DataFrame({
+            'target': range(20),
+            'num_1': range(0, -20, -1),
+            'num_2': range(10, -10, -1),
+            'cat_1': ['a'] * 20
+        })
+        df2 = DataFrame({
+            'target': range(10)
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 1., 4)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})
+
+    def test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing_2(self):
+        df1 = DataFrame({
+            'prediction': range(20),
+            'num_1': range(0, -20, -1),
+            'num_2': range(10, -10, -1),
+            'cat_1': ['a'] * 20
+        })
+        df2 = DataFrame({
+            'prediction': range(10),
+            'num_1': range(0, -10, -1),
+        })
+
+        result = self.analyzer.calculate(df1, df2, ColumnMapping())
+        self._assert_result_structure(result)
+        self.assertEqual(result['metrics']['target_name'], 'target')
+        self.assertEqual(result['metrics']['target_type'], 'num')
+        self.assertAlmostEqual(result['metrics']['target_drift'], 1., 4)
+        correlations = result['metrics']['target_correlations']
+        self.assertEqual(correlations['reference'], {'target': 1.0})
+        self.assertEqual(correlations['current'], {'target': 1.0})


### PR DESCRIPTION
- [x] Write test for current behavior
- [x] Refactor and simplify code
  - [x]   When target column is categorical, we raise a `ValueError` with explanation instead a cryptic one
- [x] Ask a bunch of questions
  - [x] Any suggestion what we should do about ` test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing` ? (the second data is missing numerical feature from the first one). Should we handle it gracefully or raise a `ValueError`
  - [x] Any suggestion what we should do about  `test_computing_of_correlations_between_columns_fails_for_second_data_when_columns_missing_2` (column names do mismatch in both datasets). Should we handle it gracefully or raise a `ValueError`

- [x]  move to pytest