### PR TITLE
Add typed results for analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ evidently/examples/.DS_Store
 evidently/nbextension/static/index.*
 .ipynb_checkpoints
 .idea
+.mypy_cache
+.pytest_cache
 dist
 build
 MANIFEST

--- a/evidently/analyzers/data_drift_analyzer.py
+++ b/evidently/analyzers/data_drift_analyzer.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 # coding: utf-8
 import collections
+from typing import Any, Dict, List
 
 import pandas as pd
 import numpy as np
+from dataclasses import dataclass, field
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
 from evidently.options import DataDriftOptions
 from evidently.analyzers.stattests import chi_stat_test, ks_stat_test, z_stat_test
-from evidently.analyzers.utils import process_columns
+from evidently.analyzers.utils import process_columns, DatasetUtilityColumns
 
 
 def dataset_drift_evaluation(p_values, drift_share=0.5):
@@ -22,19 +24,55 @@ def dataset_drift_evaluation(p_values, drift_share=0.5):
 PValueWithConfidence = collections.namedtuple("PValueWithConfidence", ["p_value", "confidence"])
 
 
+@dataclass
+class DataDriftAnalyzerResults:
+    utility_columns: DatasetUtilityColumns
+    cat_feature_names: List[str]
+    num_feature_names: List[str]
+    target_names: List[str]
+    options: DataDriftOptions
+    metrics: dict = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the analyser data to dict for data serialization"""
+        return {
+            'utility_columns': self.utility_columns.as_dict(),
+            'cat_feature_names': self.cat_feature_names,
+            'num_feature_names': self.num_feature_names,
+            'target_names': self.target_names,
+            'options': self.options.as_dict(),
+            'metrics': self.metrics
+        }
+
+    def get_all_features_list(self) -> List[str]:
+        """List all features names"""
+        return self.cat_feature_names + self.num_feature_names
+
+
 class DataDriftAnalyzer(Analyzer):
-    def calculate(self, reference_data: pd.DataFrame, current_data: pd.DataFrame, column_mapping: ColumnMapping):
+    @staticmethod
+    def get_data_drift_results(analyzer_results) -> DataDriftAnalyzerResults:
+        return analyzer_results[DataDriftAnalyzer]
+
+    def calculate(
+            self, reference_data: pd.DataFrame, current_data: pd.DataFrame, column_mapping: ColumnMapping
+    ) -> DataDriftAnalyzerResults:
         options = self.options_provider.get(DataDriftOptions)
         columns = process_columns(reference_data, column_mapping)
-        result = columns.as_dict()
+        result = DataDriftAnalyzerResults(
+            utility_columns=columns.utility_columns,
+            cat_feature_names=columns.cat_feature_names,
+            num_feature_names=columns.num_feature_names,
+            target_names=columns.target_names,
+            options=options
+        )
 
         num_feature_names = columns.num_feature_names
         cat_feature_names = columns.cat_feature_names
         drift_share = options.drift_share
 
-        result['options'] = options.as_dict()
         # calculate result
-        result['metrics'] = {}
+        result.metrics = {}
 
         p_values = {}
         for feature_name in num_feature_names:
@@ -43,7 +81,7 @@ class DataDriftAnalyzer(Analyzer):
             p_value = func(reference_data[feature_name], current_data[feature_name])
             p_values[feature_name] = PValueWithConfidence(p_value, confidence)
             current_nbinsx = options.get_nbinsx(feature_name)
-            result['metrics'][feature_name] = dict(
+            result.metrics[feature_name] = dict(
                 current_small_hist=[t.tolist() for t in
                                     np.histogram(current_data[feature_name][np.isfinite(current_data[feature_name])],
                                                  bins=current_nbinsx, density=True)],
@@ -71,7 +109,7 @@ class DataDriftAnalyzer(Analyzer):
             p_values[feature_name] = PValueWithConfidence(p_value, confidence)
 
             current_nbinsx = options.get_nbinsx(feature_name)
-            result['metrics'][feature_name] = dict(
+            result.metrics[feature_name] = dict(
                 current_small_hist=[t.tolist() for t in
                                     np.histogram(current_data[feature_name][np.isfinite(current_data[feature_name])],
                                                  bins=current_nbinsx, density=True)],
@@ -83,8 +121,8 @@ class DataDriftAnalyzer(Analyzer):
             )
 
         n_drifted_features, share_drifted_features, dataset_drift = dataset_drift_evaluation(p_values, drift_share)
-        result['metrics']['n_features'] = len(num_feature_names) + len(cat_feature_names)
-        result['metrics']['n_drifted_features'] = n_drifted_features
-        result['metrics']['share_drifted_features'] = share_drifted_features
-        result['metrics']['dataset_drift'] = dataset_drift
+        result.metrics['n_features'] = len(num_feature_names) + len(cat_feature_names)
+        result.metrics['n_drifted_features'] = n_drifted_features
+        result.metrics['share_drifted_features'] = share_drifted_features
+        result.metrics['dataset_drift'] = dataset_drift
         return result

--- a/evidently/analyzers/data_drift_analyzer.py
+++ b/evidently/analyzers/data_drift_analyzer.py
@@ -89,7 +89,7 @@ class DataDriftAnalyzerResults:
 
 class DataDriftAnalyzer(Analyzer):
     @staticmethod
-    def get_data_drift_results(analyzer_results) -> DataDriftAnalyzerResults:
+    def get_results(analyzer_results) -> DataDriftAnalyzerResults:
         return analyzer_results[DataDriftAnalyzer]
 
     def calculate(

--- a/evidently/analyzers/data_drift_analyzer.py
+++ b/evidently/analyzers/data_drift_analyzer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 import collections
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 import numpy as np
@@ -31,14 +31,6 @@ class DataDriftAnalyzerFeatureMetrics:
     feature_type: str
     p_value: float
 
-    def as_dict(self) -> Dict[str, Any]:
-        return {
-            'current_small_hist': self.current_small_hist,
-            'ref_small_hist': self.ref_small_hist,
-            'feature_type': self.feature_type,
-            'p_value': self.p_value,
-        }
-
 
 @dataclass
 class DataDriftAnalyzerMetrics:
@@ -47,19 +39,6 @@ class DataDriftAnalyzerMetrics:
     share_drifted_features: float
     dataset_drift: bool
     features: Dict[str, DataDriftAnalyzerFeatureMetrics]
-
-    def as_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
-            'n_features': self.n_features,
-            'n_drifted_features': self.n_drifted_features,
-            'share_drifted_features': self.share_drifted_features,
-            'dataset_drift': self.dataset_drift
-        }
-
-        for feature_name, feature_metrics in self.features.items():
-            result[feature_name] = feature_metrics.as_dict()
-
-        return result
 
 
 @dataclass
@@ -70,17 +49,6 @@ class DataDriftAnalyzerResults:
     target_names: Optional[List[str]]
     options: DataDriftOptions
     metrics: DataDriftAnalyzerMetrics
-
-    def as_dict(self) -> Dict[str, Any]:
-        """Convert the analyser data to dict for data serialization"""
-        return {
-            'utility_columns': self.utility_columns.as_dict(),
-            'cat_feature_names': self.cat_feature_names,
-            'num_feature_names': self.num_feature_names,
-            'target_names': self.target_names,
-            'options': self.options.as_dict(),
-            'metrics': self.metrics.as_dict()
-        }
 
     def get_all_features_list(self) -> List[str]:
         """List all features names"""

--- a/evidently/analyzers/data_drift_analyzer.py
+++ b/evidently/analyzers/data_drift_analyzer.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # coding: utf-8
 import collections
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import numpy as np
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
@@ -14,7 +14,7 @@ from evidently.analyzers.stattests import chi_stat_test, ks_stat_test, z_stat_te
 from evidently.analyzers.utils import process_columns, DatasetUtilityColumns
 
 
-def dataset_drift_evaluation(p_values, drift_share=0.5):
+def dataset_drift_evaluation(p_values, drift_share=0.5) -> Tuple[int, float, bool]:
     n_drifted_features = sum([1 if x.p_value < (1. - x.confidence) else 0 for _, x in p_values.items()])
     share_drifted_features = n_drifted_features / len(p_values)
     dataset_drift = bool(share_drifted_features >= drift_share)
@@ -25,15 +25,53 @@ PValueWithConfidence = collections.namedtuple("PValueWithConfidence", ["p_value"
 
 
 @dataclass
+class DataDriftAnalyzerFeatureMetrics:
+    current_small_hist: list
+    ref_small_hist: list
+    feature_type: str
+    p_value: float
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            'current_small_hist': self.current_small_hist,
+            'ref_small_hist': self.ref_small_hist,
+            'feature_type': self.feature_type,
+            'p_value': self.p_value,
+        }
+
+
+@dataclass
+class DataDriftAnalyzerMetrics:
+    n_features: int
+    n_drifted_features: int
+    share_drifted_features: float
+    dataset_drift: bool
+    features: Dict[str, DataDriftAnalyzerFeatureMetrics]
+
+    def as_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            'n_features': self.n_features,
+            'n_drifted_features': self.n_drifted_features,
+            'share_drifted_features': self.share_drifted_features,
+            'dataset_drift': self.dataset_drift
+        }
+
+        for feature_name, feature_metrics in self.features.items():
+            result[feature_name] = feature_metrics.as_dict()
+
+        return result
+
+
+@dataclass
 class DataDriftAnalyzerResults:
     utility_columns: DatasetUtilityColumns
     cat_feature_names: List[str]
     num_feature_names: List[str]
-    target_names: List[str]
+    target_names: Optional[List[str]]
     options: DataDriftOptions
-    metrics: dict = field(default_factory=dict)
+    metrics: DataDriftAnalyzerMetrics
 
-    def to_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> Dict[str, Any]:
         """Convert the analyser data to dict for data serialization"""
         return {
             'utility_columns': self.utility_columns.as_dict(),
@@ -41,7 +79,7 @@ class DataDriftAnalyzerResults:
             'num_feature_names': self.num_feature_names,
             'target_names': self.target_names,
             'options': self.options.as_dict(),
-            'metrics': self.metrics
+            'metrics': self.metrics.as_dict()
         }
 
     def get_all_features_list(self) -> List[str]:
@@ -59,29 +97,21 @@ class DataDriftAnalyzer(Analyzer):
     ) -> DataDriftAnalyzerResults:
         options = self.options_provider.get(DataDriftOptions)
         columns = process_columns(reference_data, column_mapping)
-        result = DataDriftAnalyzerResults(
-            utility_columns=columns.utility_columns,
-            cat_feature_names=columns.cat_feature_names,
-            num_feature_names=columns.num_feature_names,
-            target_names=columns.target_names,
-            options=options
-        )
-
         num_feature_names = columns.num_feature_names
         cat_feature_names = columns.cat_feature_names
         drift_share = options.drift_share
 
         # calculate result
-        result.metrics = {}
-
+        features_metrics = {}
         p_values = {}
+
         for feature_name in num_feature_names:
             confidence = options.get_confidence(feature_name)
             func = options.get_feature_stattest_func(feature_name, ks_stat_test)
             p_value = func(reference_data[feature_name], current_data[feature_name])
             p_values[feature_name] = PValueWithConfidence(p_value, confidence)
             current_nbinsx = options.get_nbinsx(feature_name)
-            result.metrics[feature_name] = dict(
+            features_metrics[feature_name] = DataDriftAnalyzerFeatureMetrics(
                 current_small_hist=[t.tolist() for t in
                                     np.histogram(current_data[feature_name][np.isfinite(current_data[feature_name])],
                                                  bins=current_nbinsx, density=True)],
@@ -109,7 +139,7 @@ class DataDriftAnalyzer(Analyzer):
             p_values[feature_name] = PValueWithConfidence(p_value, confidence)
 
             current_nbinsx = options.get_nbinsx(feature_name)
-            result.metrics[feature_name] = dict(
+            features_metrics[feature_name] = DataDriftAnalyzerFeatureMetrics(
                 current_small_hist=[t.tolist() for t in
                                     np.histogram(current_data[feature_name][np.isfinite(current_data[feature_name])],
                                                  bins=current_nbinsx, density=True)],
@@ -121,8 +151,19 @@ class DataDriftAnalyzer(Analyzer):
             )
 
         n_drifted_features, share_drifted_features, dataset_drift = dataset_drift_evaluation(p_values, drift_share)
-        result.metrics['n_features'] = len(num_feature_names) + len(cat_feature_names)
-        result.metrics['n_drifted_features'] = n_drifted_features
-        result.metrics['share_drifted_features'] = share_drifted_features
-        result.metrics['dataset_drift'] = dataset_drift
+        result_metrics = DataDriftAnalyzerMetrics(
+            n_features=len(num_feature_names) + len(cat_feature_names),
+            n_drifted_features=n_drifted_features,
+            share_drifted_features=share_drifted_features,
+            dataset_drift=dataset_drift,
+            features=features_metrics,
+        )
+        result = DataDriftAnalyzerResults(
+            utility_columns=columns.utility_columns,
+            cat_feature_names=columns.cat_feature_names,
+            num_feature_names=columns.num_feature_names,
+            target_names=columns.target_names,
+            options=options,
+            metrics=result_metrics,
+        )
         return result

--- a/evidently/analyzers/test_data_drift_analyzer.py
+++ b/evidently/analyzers/test_data_drift_analyzer.py
@@ -1,9 +1,11 @@
+import json
 import pytest
 from pandas import DataFrame
 
 from evidently import ColumnMapping
 from evidently.analyzers.data_drift_analyzer import DataDriftAnalyzer
 from evidently.options import DataDriftOptions, OptionsProvider
+from evidently.utils import NumpyEncoder
 
 
 @pytest.fixture
@@ -64,3 +66,5 @@ def test_data_drift_analyzer_as_dict_format(analyzer: DataDriftAnalyzer) -> None
     _check_feature_metrics(result_as_dict['metrics']['categorical_feature_1'], 'cat')
     assert 'categorical_feature_2' in result_as_dict['metrics']
     _check_feature_metrics(result_as_dict['metrics']['categorical_feature_2'], 'cat')
+
+    json.dumps(result_as_dict, cls=NumpyEncoder)

--- a/evidently/analyzers/test_data_drift_analyzer.py
+++ b/evidently/analyzers/test_data_drift_analyzer.py
@@ -1,15 +1,13 @@
-import json
 import pytest
 from pandas import DataFrame
 
 from evidently import ColumnMapping
 from evidently.analyzers.data_drift_analyzer import DataDriftAnalyzer
 from evidently.options import DataDriftOptions, OptionsProvider
-from evidently.utils import NumpyEncoder
 
 
 @pytest.fixture
-def analyzer() -> DataDriftAnalyzer:
+def data_drift_analyzer() -> DataDriftAnalyzer:
     options_provider: OptionsProvider = OptionsProvider()
     options_provider.add(DataDriftOptions())
     analyzer = DataDriftAnalyzer()
@@ -17,15 +15,7 @@ def analyzer() -> DataDriftAnalyzer:
     return analyzer
 
 
-def _check_feature_metrics(feature_metric: dict, feature_type: str):
-    assert 'current_small_hist' in feature_metric
-    assert 'feature_type' in feature_metric
-    assert feature_metric['feature_type'] == feature_type
-    assert 'p_value' in feature_metric
-    assert 'ref_small_hist' in feature_metric
-
-
-def test_data_drift_analyzer_as_dict_format(analyzer: DataDriftAnalyzer) -> None:
+def test_data_drift_analyzer_as_dict_format(data_drift_analyzer: DataDriftAnalyzer) -> None:
     test_data = DataFrame({
         'target': [1, 2, 3, 4],
         'numerical_feature_1': [0.5, 0.0, 4.8, 2.1],
@@ -39,32 +29,22 @@ def test_data_drift_analyzer_as_dict_format(analyzer: DataDriftAnalyzer) -> None
     data_columns.numerical_features = ['numerical_feature_1', 'numerical_feature_2']
     data_columns.categorical_features = ['categorical_feature_1', 'categorical_feature_2']
     data_columns.target_names = ['drift_target']
-    result = analyzer.calculate(test_data[:2], test_data, data_columns)
-    result_as_dict = result.as_dict()
-    assert 'cat_feature_names' in result_as_dict
-    assert result_as_dict['cat_feature_names'] == ['categorical_feature_1', 'categorical_feature_2']
-    assert 'num_feature_names' in result_as_dict
-    assert result_as_dict['num_feature_names'] == ['numerical_feature_1', 'numerical_feature_2']
+    result = data_drift_analyzer.calculate(test_data[:2], test_data, data_columns)
+    assert result.options is not None
+    assert result.utility_columns is not None
+    # check features in results
+    assert result.metrics.n_features == 4
+    assert result.cat_feature_names == ['categorical_feature_1', 'categorical_feature_2']
+    assert result.num_feature_names == ['numerical_feature_1', 'numerical_feature_2']
+    assert result.get_all_features_list() == [
+        'categorical_feature_1', 'categorical_feature_2', 'numerical_feature_1', 'numerical_feature_2'
+    ]
+    assert 'numerical_feature_1' in result.metrics.features
+    assert 'numerical_feature_2' in result.metrics.features
+    assert 'categorical_feature_1' in result.metrics.features
+    assert 'categorical_feature_2' in result.metrics.features
+    assert 'numerical_feature_3' not in result.metrics.features
 
-    assert 'options' in result_as_dict
-    assert 'target_names' in result_as_dict
-    assert result_as_dict['target_names'] == ['drift_target']
-    assert 'utility_columns' in result_as_dict
-
-    assert 'metrics' in result_as_dict
-    assert 'dataset_drift' in result_as_dict['metrics']
-    assert 'n_drifted_features' in result_as_dict['metrics']
-    assert 'n_features' in result_as_dict['metrics']
-    assert result_as_dict['metrics']['n_features'] == 4
-    assert 'dataset_drift' in result_as_dict['metrics']
-
-    assert 'numerical_feature_1' in result_as_dict['metrics']
-    _check_feature_metrics(result_as_dict['metrics']['numerical_feature_1'], 'num')
-    assert 'numerical_feature_2' in result_as_dict['metrics']
-    _check_feature_metrics(result_as_dict['metrics']['numerical_feature_2'], 'num')
-    assert 'categorical_feature_1' in result_as_dict['metrics']
-    _check_feature_metrics(result_as_dict['metrics']['categorical_feature_1'], 'cat')
-    assert 'categorical_feature_2' in result_as_dict['metrics']
-    _check_feature_metrics(result_as_dict['metrics']['categorical_feature_2'], 'cat')
-
-    json.dumps(result_as_dict, cls=NumpyEncoder)
+    # check data drift results
+    assert result.target_names == ['drift_target']
+    assert result.metrics.dataset_drift is False

--- a/evidently/analyzers/test_data_drift_analyzer.py
+++ b/evidently/analyzers/test_data_drift_analyzer.py
@@ -1,0 +1,66 @@
+import pytest
+from pandas import DataFrame
+
+from evidently import ColumnMapping
+from evidently.analyzers.data_drift_analyzer import DataDriftAnalyzer
+from evidently.options import DataDriftOptions, OptionsProvider
+
+
+@pytest.fixture
+def analyzer() -> DataDriftAnalyzer:
+    options_provider: OptionsProvider = OptionsProvider()
+    options_provider.add(DataDriftOptions())
+    analyzer = DataDriftAnalyzer()
+    analyzer.options_provider = options_provider
+    return analyzer
+
+
+def _check_feature_metrics(feature_metric: dict, feature_type: str):
+    assert 'current_small_hist' in feature_metric
+    assert 'feature_type' in feature_metric
+    assert feature_metric['feature_type'] == feature_type
+    assert 'p_value' in feature_metric
+    assert 'ref_small_hist' in feature_metric
+
+
+def test_data_drift_analyzer_as_dict_format(analyzer: DataDriftAnalyzer) -> None:
+    test_data = DataFrame({
+        'target': [1, 2, 3, 4],
+        'numerical_feature_1': [0.5, 0.0, 4.8, 2.1],
+        'numerical_feature_2': [0, 5, 6, 3],
+        'numerical_feature_3': [4, 5.5, 4, 0],
+        'categorical_feature_1': [1, 1, 0, 1],
+        'categorical_feature_2': [0, 1, 0, 0],
+    })
+
+    data_columns = ColumnMapping()
+    data_columns.numerical_features = ['numerical_feature_1', 'numerical_feature_2']
+    data_columns.categorical_features = ['categorical_feature_1', 'categorical_feature_2']
+    data_columns.target_names = ['drift_target']
+    result = analyzer.calculate(test_data[:2], test_data, data_columns)
+    result_as_dict = result.as_dict()
+    assert 'cat_feature_names' in result_as_dict
+    assert result_as_dict['cat_feature_names'] == ['categorical_feature_1', 'categorical_feature_2']
+    assert 'num_feature_names' in result_as_dict
+    assert result_as_dict['num_feature_names'] == ['numerical_feature_1', 'numerical_feature_2']
+
+    assert 'options' in result_as_dict
+    assert 'target_names' in result_as_dict
+    assert result_as_dict['target_names'] == ['drift_target']
+    assert 'utility_columns' in result_as_dict
+
+    assert 'metrics' in result_as_dict
+    assert 'dataset_drift' in result_as_dict['metrics']
+    assert 'n_drifted_features' in result_as_dict['metrics']
+    assert 'n_features' in result_as_dict['metrics']
+    assert result_as_dict['metrics']['n_features'] == 4
+    assert 'dataset_drift' in result_as_dict['metrics']
+
+    assert 'numerical_feature_1' in result_as_dict['metrics']
+    _check_feature_metrics(result_as_dict['metrics']['numerical_feature_1'], 'num')
+    assert 'numerical_feature_2' in result_as_dict['metrics']
+    _check_feature_metrics(result_as_dict['metrics']['numerical_feature_2'], 'num')
+    assert 'categorical_feature_1' in result_as_dict['metrics']
+    _check_feature_metrics(result_as_dict['metrics']['categorical_feature_1'], 'cat')
+    assert 'categorical_feature_2' in result_as_dict['metrics']
+    _check_feature_metrics(result_as_dict['metrics']['categorical_feature_2'], 'cat')

--- a/evidently/model_monitoring/data_drift.py
+++ b/evidently/model_monitoring/data_drift.py
@@ -18,12 +18,12 @@ class DataDriftMonitor(ModelMonitor):
 
     def metrics(self, analyzer_results):
         data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzer_results)
-        yield DataDriftMetrics.share_drifted_features.create(data_drift_results.metrics['share_drifted_features'])
-        yield DataDriftMetrics.n_drifted_features.create(data_drift_results.metrics['n_drifted_features'])
-        yield DataDriftMetrics.dataset_drift.create(data_drift_results.metrics['dataset_drift'])
+        yield DataDriftMetrics.share_drifted_features.create(data_drift_results.metrics.share_drifted_features)
+        yield DataDriftMetrics.n_drifted_features.create(data_drift_results.metrics.n_drifted_features)
+        yield DataDriftMetrics.dataset_drift.create(data_drift_results.metrics.dataset_drift)
 
-        for feature in data_drift_results.get_all_features_list():
-            feature_metric = data_drift_results.metrics[feature]
+        for feature_name in data_drift_results.get_all_features_list():
+            feature_metric = data_drift_results.metrics.features[feature_name]
             yield DataDriftMetrics.p_value.create(
-                feature_metric['p_value'],
-                dict(feature=feature, feature_type=feature_metric['feature_type']))
+                feature_metric.p_value,
+                dict(feature=feature_name, feature_type=feature_metric.feature_type))

--- a/evidently/model_monitoring/data_drift.py
+++ b/evidently/model_monitoring/data_drift.py
@@ -17,13 +17,13 @@ class DataDriftMonitor(ModelMonitor):
         return [DataDriftAnalyzer]
 
     def metrics(self, analyzer_results):
-        data_drift_results = analyzer_results[DataDriftAnalyzer]
-        features = data_drift_results['cat_feature_names'] + data_drift_results['num_feature_names']
-        yield DataDriftMetrics.share_drifted_features.create(data_drift_results['metrics']['share_drifted_features'])
-        yield DataDriftMetrics.n_drifted_features.create(data_drift_results['metrics']['n_drifted_features'])
-        yield DataDriftMetrics.dataset_drift.create(data_drift_results['metrics']['dataset_drift'])
-        for feature in features:
-            feature_metric = data_drift_results['metrics'][feature]
+        data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzer_results)
+        yield DataDriftMetrics.share_drifted_features.create(data_drift_results.metrics['share_drifted_features'])
+        yield DataDriftMetrics.n_drifted_features.create(data_drift_results.metrics['n_drifted_features'])
+        yield DataDriftMetrics.dataset_drift.create(data_drift_results.metrics['dataset_drift'])
+
+        for feature in data_drift_results.get_all_features_list():
+            feature_metric = data_drift_results.metrics[feature]
             yield DataDriftMetrics.p_value.create(
                 feature_metric['p_value'],
                 dict(feature=feature, feature_type=feature_metric['feature_type']))

--- a/evidently/model_monitoring/data_drift.py
+++ b/evidently/model_monitoring/data_drift.py
@@ -17,7 +17,7 @@ class DataDriftMonitor(ModelMonitor):
         return [DataDriftAnalyzer]
 
     def metrics(self, analyzer_results):
-        data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzer_results)
+        data_drift_results = DataDriftAnalyzer.get_results(analyzer_results)
         yield DataDriftMetrics.share_drifted_features.create(data_drift_results.metrics.share_drifted_features)
         yield DataDriftMetrics.n_drifted_features.create(data_drift_results.metrics.n_drifted_features)
         yield DataDriftMetrics.dataset_drift.create(data_drift_results.metrics.dataset_drift)

--- a/evidently/profile_sections/data_drift_profile_section.py
+++ b/evidently/profile_sections/data_drift_profile_section.py
@@ -21,7 +21,7 @@ class DataDriftProfileSection(ProfileSection):
         self._result = {
             'name': self.part_id(),
             'datetime': str(datetime.now()),
-            'data': data_drift_results.to_dict()
+            'data': data_drift_results.as_dict()
         }
 
     def get_results(self):

--- a/evidently/profile_sections/data_drift_profile_section.py
+++ b/evidently/profile_sections/data_drift_profile_section.py
@@ -17,11 +17,11 @@ class DataDriftProfileSection(ProfileSection):
         return self.analyzers_types
 
     def calculate(self, reference_data, current_data, column_mapping, analyzers_results):
-        result = analyzers_results[DataDriftAnalyzer]
+        data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzers_results)
         self._result = {
             'name': self.part_id(),
             'datetime': str(datetime.now()),
-            'data': result
+            'data': data_drift_results.to_dict()
         }
 
     def get_results(self):

--- a/evidently/profile_sections/data_drift_profile_section.py
+++ b/evidently/profile_sections/data_drift_profile_section.py
@@ -17,7 +17,7 @@ class DataDriftProfileSection(ProfileSection):
         return self.analyzers_types
 
     def calculate(self, reference_data, current_data, column_mapping, analyzers_results):
-        data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzers_results)
+        data_drift_results = DataDriftAnalyzer.get_results(analyzers_results)
         self._result = {
             'name': self.part_id(),
             'datetime': str(datetime.now()),

--- a/evidently/profile_sections/data_drift_profile_section.py
+++ b/evidently/profile_sections/data_drift_profile_section.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Dict, Optional, Union
 
 from evidently.analyzers.data_drift_analyzer import DataDriftAnalyzer
 from evidently.profile_sections.base_profile_section import ProfileSection
@@ -16,13 +17,35 @@ class DataDriftProfileSection(ProfileSection):
     def analyzers(self):
         return self.analyzers_types
 
-    def calculate(self, reference_data, current_data, column_mapping, analyzers_results):
+    def calculate(self, reference_data, current_data, column_mapping, analyzers_results) -> None:
         data_drift_results = DataDriftAnalyzer.get_results(analyzers_results)
+        metrics_dict: Dict[str, Union[int, bool, float, Dict]] = {
+            'n_features': data_drift_results.metrics.n_features,
+            'n_drifted_features': data_drift_results.metrics.n_drifted_features,
+            'share_drifted_features': data_drift_results.metrics.share_drifted_features,
+            'dataset_drift': data_drift_results.metrics.dataset_drift
+        }
+        # add metrics to a flat dict with data drift results
+        for feature_name, feature_metrics in data_drift_results.metrics.features.items():
+            metrics_dict[feature_name] = {
+                'current_small_hist': feature_metrics.current_small_hist,
+                'ref_small_hist': feature_metrics.ref_small_hist,
+                'feature_type': feature_metrics.feature_type,
+                'p_value': feature_metrics.p_value,
+            }
+
         self._result = {
             'name': self.part_id(),
             'datetime': str(datetime.now()),
-            'data': data_drift_results.as_dict()
+            'data': {
+                'utility_columns': data_drift_results.utility_columns.as_dict(),
+                'cat_feature_names': data_drift_results.cat_feature_names,
+                'num_feature_names': data_drift_results.num_feature_names,
+                'target_names': data_drift_results.target_names,
+                'options': data_drift_results.options.as_dict(),
+                'metrics': metrics_dict
+            }
         }
 
-    def get_results(self):
+    def get_results(self) -> Optional[Dict[str, Union[str, Dict]]]:
         return self._result

--- a/evidently/profile_sections/test_data_drift_profile_section.py
+++ b/evidently/profile_sections/test_data_drift_profile_section.py
@@ -1,0 +1,80 @@
+import json
+
+from pandas import DataFrame
+
+from evidently import ColumnMapping
+from evidently.analyzers.data_drift_analyzer import DataDriftAnalyzer
+from evidently.options import DataDriftOptions, OptionsProvider
+from evidently.profile_sections.data_drift_profile_section import DataDriftProfileSection
+from evidently.utils import NumpyEncoder
+
+
+def _check_feature_metrics(feature_metric: dict, feature_type: str):
+    assert 'current_small_hist' in feature_metric
+    assert 'feature_type' in feature_metric
+    assert feature_metric['feature_type'] == feature_type
+    assert 'p_value' in feature_metric
+    assert 'ref_small_hist' in feature_metric
+
+
+def test_data_drift_profile_section_empty_results():
+    data_drift_profile_section = DataDriftProfileSection()
+    assert data_drift_profile_section.analyzers() == [DataDriftAnalyzer]
+    assert data_drift_profile_section.part_id() == 'data_drift'
+
+    empty_result = data_drift_profile_section.get_results()
+    assert empty_result is None
+
+
+def test_data_drift_profile_section_with_calculated_results():
+    # prepare calculated data
+    options_provider: OptionsProvider = OptionsProvider()
+    options_provider.add(DataDriftOptions())
+    data_drift_analyzer = DataDriftAnalyzer()
+    data_drift_analyzer.options_provider = options_provider
+    test_data = DataFrame({
+        'target': [1, 2, 3, 4],
+        'numerical_feature': [0.5, 0.0, 4.8, 2.1],
+        'categorical_feature': [1, 1, 0, 1],
+    })
+    data_columns = ColumnMapping(
+        numerical_features=['numerical_feature'],
+        categorical_features=['categorical_feature'],
+        target_names=['drift_target_result']
+    )
+    data_drift_results = data_drift_analyzer.calculate(test_data[:2], test_data, data_columns)
+    analyzers_results = {DataDriftAnalyzer: data_drift_results}
+
+    # create data_drift_profile section with the calculated data
+    data_drift_profile_section = DataDriftProfileSection()
+    data_drift_profile_section.calculate(test_data[:2], test_data, data_columns, analyzers_results)
+    data_drift_profile_section_result = data_drift_profile_section.get_results()
+    assert 'name' in data_drift_profile_section_result
+    assert data_drift_profile_section_result['name'] == 'data_drift'
+    assert 'datetime' in data_drift_profile_section_result
+    assert isinstance(data_drift_profile_section_result['datetime'], str)
+    assert 'data' in data_drift_profile_section_result
+    assert isinstance(data_drift_profile_section_result['data'], dict)
+
+    result_data = data_drift_profile_section_result['data']
+
+    assert 'cat_feature_names' in result_data
+    assert result_data['cat_feature_names'] == ['categorical_feature']
+    assert 'num_feature_names' in result_data
+    assert result_data['num_feature_names'] == ['numerical_feature']
+    assert 'options' in result_data
+    assert 'target_names' in result_data
+    assert result_data['target_names'] == ['drift_target_result']
+    assert 'utility_columns' in result_data
+    assert 'metrics' in result_data
+    assert 'dataset_drift' in result_data['metrics']
+    assert 'n_drifted_features' in result_data['metrics']
+    assert 'n_features' in result_data['metrics']
+    assert result_data['metrics']['n_features'] == 2
+    assert 'numerical_feature' in result_data['metrics']
+    _check_feature_metrics(result_data['metrics']['numerical_feature'], 'num')
+    assert 'categorical_feature' in result_data['metrics']
+    _check_feature_metrics(result_data['metrics']['categorical_feature'], 'cat')
+
+    # check json serialization
+    json.dumps(data_drift_profile_section_result, cls=NumpyEncoder)

--- a/evidently/tests/test_readme_examples.py
+++ b/evidently/tests/test_readme_examples.py
@@ -78,7 +78,12 @@ def test_data_drift_dashboard(iris_frame) -> None:
     actual = json.loads(iris_data_drift_report._json())
     # we leave the actual content test to other tests for widgets
     assert 'name' in actual
+    assert len(actual['name']) > 0
+    assert 'widgets' in actual
     assert len(actual['widgets']) == 1
+    data_drift_widget_data = actual['widgets'][0]
+    assert 'type' in data_drift_widget_data
+    assert 'title' in data_drift_widget_data
 
 
 def test_data_drift_categorical_target_drift_dashboard(iris_frame) -> None:

--- a/evidently/widgets/data_drift_table_widget.py
+++ b/evidently/widgets/data_drift_table_widget.py
@@ -32,11 +32,10 @@ class DataDriftTableWidget(Widget):
         params_data = []
         options = self.options_provider.get(DataDriftOptions)
         for feature_name in all_features:
-            current_small_hist = data_drift_results.metrics[feature_name]["current_small_hist"]
-            ref_small_hist = data_drift_results.metrics[feature_name]["ref_small_hist"]
-            feature_type = data_drift_results.metrics[feature_name]["feature_type"]
-
-            p_value = data_drift_results.metrics[feature_name]["p_value"]
+            current_small_hist = data_drift_results.metrics.features[feature_name].current_small_hist
+            ref_small_hist = data_drift_results.metrics.features[feature_name].ref_small_hist
+            feature_type = data_drift_results.metrics.features[feature_name].feature_type
+            p_value = data_drift_results.metrics.features[feature_name].p_value
             feature_confidence = options.get_confidence(feature_name)
             distr_sim_test = "Detected" if p_value < (1. - feature_confidence) else "Not Detected"
 
@@ -204,10 +203,10 @@ class DataDriftTableWidget(Widget):
                     }
                 )
             )
-        n_drifted_features = data_drift_results.metrics['n_drifted_features']
-        dataset_drift = data_drift_results.metrics['dataset_drift']
-        n_features = data_drift_results.metrics['n_features']
-        drift_share = data_drift_results.metrics['share_drifted_features']
+        n_drifted_features = data_drift_results.metrics.n_drifted_features
+        dataset_drift = data_drift_results.metrics.dataset_drift
+        n_features = data_drift_results.metrics.n_features
+        drift_share = data_drift_results.metrics.share_drifted_features
 
         title_prefix = f'Drift is detected for {drift_share * 100:.2f}% of features ({n_drifted_features}' \
                        f' out of {n_features}). '

--- a/evidently/widgets/data_drift_table_widget.py
+++ b/evidently/widgets/data_drift_table_widget.py
@@ -24,20 +24,19 @@ class DataDriftTableWidget(Widget):
                   current_data: pd.DataFrame,
                   column_mapping: ColumnMapping,
                   analyzers_results) -> Optional[BaseWidgetInfo]:
-        results = analyzers_results[DataDriftAnalyzer]
-        num_feature_names = results["num_feature_names"]
-        cat_feature_names = results["cat_feature_names"]
-        date_column = results['utility_columns']['date']
+        data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzers_results)
+        all_features = data_drift_results.get_all_features_list()
+        date_column = data_drift_results.utility_columns.date
 
         # set params data
         params_data = []
         options = self.options_provider.get(DataDriftOptions)
-        for feature_name in num_feature_names + cat_feature_names:
-            current_small_hist = results['metrics'][feature_name]["current_small_hist"]
-            ref_small_hist = results['metrics'][feature_name]["ref_small_hist"]
-            feature_type = results['metrics'][feature_name]["feature_type"]
+        for feature_name in all_features:
+            current_small_hist = data_drift_results.metrics[feature_name]["current_small_hist"]
+            ref_small_hist = data_drift_results.metrics[feature_name]["ref_small_hist"]
+            feature_type = data_drift_results.metrics[feature_name]["feature_type"]
 
-            p_value = results['metrics'][feature_name]["p_value"]
+            p_value = data_drift_results.metrics[feature_name]["p_value"]
             feature_confidence = options.get_confidence(feature_name)
             distr_sim_test = "Detected" if p_value < (1. - feature_confidence) else "Not Detected"
 
@@ -75,7 +74,7 @@ class DataDriftTableWidget(Widget):
         # set additionalGraphs
         additional_graphs_data = []
         xbins = options.xbins
-        for feature_name in num_feature_names + cat_feature_names:
+        for feature_name in all_features:
             # plot distributions
             fig = go.Figure()
             if xbins and xbins.get(feature_name):
@@ -205,10 +204,10 @@ class DataDriftTableWidget(Widget):
                     }
                 )
             )
-        n_drifted_features = results['metrics']['n_drifted_features']
-        dataset_drift = results['metrics']['dataset_drift']
-        n_features = results['metrics']['n_features']
-        drift_share = results['metrics']['share_drifted_features']
+        n_drifted_features = data_drift_results.metrics['n_drifted_features']
+        dataset_drift = data_drift_results.metrics['dataset_drift']
+        n_features = data_drift_results.metrics['n_features']
+        drift_share = data_drift_results.metrics['share_drifted_features']
 
         title_prefix = f'Drift is detected for {drift_share * 100:.2f}% of features ({n_drifted_features}' \
                        f' out of {n_features}). '

--- a/evidently/widgets/data_drift_table_widget.py
+++ b/evidently/widgets/data_drift_table_widget.py
@@ -24,7 +24,7 @@ class DataDriftTableWidget(Widget):
                   current_data: pd.DataFrame,
                   column_mapping: ColumnMapping,
                   analyzers_results) -> Optional[BaseWidgetInfo]:
-        data_drift_results = DataDriftAnalyzer.get_data_drift_results(analyzers_results)
+        data_drift_results = DataDriftAnalyzer.get_results(analyzers_results)
         all_features = data_drift_results.get_all_features_list()
         date_column = data_drift_results.utility_columns.date
 


### PR DESCRIPTION
- add DataDriftAnalyzerResults for DataDriftAnalyzer
- move data drift analyser results to DataDriftAnalyzerResults instance, not dict (TODO: move metrics from dict to a dataclass object)
- simplify metrics names iteration (TODO: add some lazy calculations optimisations)
- add a test for DataDriftAnalyzerResults serialization to dict

aux changes:
- add mypy and pytest caches to git ignore settings