### PR TITLE
Fix ValueError: Widget [Current: Mean Error per Group (+/- std) ] required 'current'

### DIFF
--- a/example_test.py
+++ b/example_test.py
@@ -1,8 +1,7 @@
 import os
 import sys
 
-excludes = ['bicycle_demand_monitoring.py',
-            'historical_drift_visualization.py',
+excludes = ['historical_drift_visualization.py',
             'mlflow_integration.py',
             'ibm_hr_attrition_model_validation.py',
             ]

--- a/src/evidently/dashboard/widgets/reg_underperform_metrics_widget.py
+++ b/src/evidently/dashboard/widgets/reg_underperform_metrics_widget.py
@@ -49,6 +49,9 @@ class RegUnderperformMetricsWidget(Widget):
                 raise ValueError(f"Widget [{self.title}] required 'reference' results from"
                                  f" {RegressionPerformanceAnalyzer.__name__} but no data found")
 
+        if result_metrics is None:
+            raise ValueError(f"Widget [{self.title}] unexpected behaviour. Var 'result_metrics should be set")
+
         return BaseWidgetInfo(
             title=self.title,
             type="counter",

--- a/src/evidently/dashboard/widgets/reg_underperform_metrics_widget.py
+++ b/src/evidently/dashboard/widgets/reg_underperform_metrics_widget.py
@@ -39,10 +39,8 @@ class RegUnderperformMetricsWidget(Widget):
 
         if self.dataset == 'current':
             result_metrics = results.current_metrics
-
             if result_metrics is None:
-                raise ValueError(f"Widget [{self.title}] required 'current' results from"
-                                 f" {RegressionPerformanceAnalyzer.__name__} but no data found")
+                return None
 
         elif self.dataset == 'reference':
             result_metrics = results.reference_metrics
@@ -50,9 +48,6 @@ class RegUnderperformMetricsWidget(Widget):
             if result_metrics is None:
                 raise ValueError(f"Widget [{self.title}] required 'reference' results from"
                                  f" {RegressionPerformanceAnalyzer.__name__} but no data found")
-
-        if result_metrics is None:
-            return None
 
         return BaseWidgetInfo(
             title=self.title,

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -108,14 +108,18 @@ def test_regression_performance_dashboard(iris_frame) -> None:
     assert len(actual['widgets']) == 20
 
 
-def test_regression_performance_single_frame_dashboard_value_error(iris_frame) -> None:
-    # when prediction column is not present in the dataset
-    # ValueError: [Widget Regression Model Performance Report.]
+def test_regression_performance_single_frame_dashboard(iris_frame) -> None:
+    # You can also generate a **Regression Model Performance** for a single `DataFrame`. In this case, run:
+    # FIXME: when prediction column is not present in the dataset
+    #   ValueError: [Widget Regression Model Performance Report.] wi is None,
+    #   no data available (forget to set it in widget?)
     iris_frame['prediction'] = iris_frame['target'][::-1]
     regression_single_model_performance = Dashboard(tabs=[RegressionPerformanceTab()])
+    regression_single_model_performance.calculate(iris_frame, None)
+    actual = json.loads(regression_single_model_performance._json())
+    assert 'name' in actual
+    assert len(actual['widgets']) == 11
 
-    with pytest.raises(ValueError):
-        regression_single_model_performance.calculate(iris_frame, None)
 
 
 def test_classification_performance_dashboard(iris_frame) -> None:


### PR DESCRIPTION
Fix ValueError: Widget [Current: Mean Error per Group (+/- std) ] required 'current' results from RegressionPerformanceAnalyzer but no data found in RegressionPerformanceTab.