### PR TITLE
add a base class for analyzers results

### DIFF
--- a/src/evidently/analyzers/base_analyzer.py
+++ b/src/evidently/analyzers/base_analyzer.py
@@ -4,9 +4,27 @@ import abc
 from typing import Optional
 
 import pandas as pd
+from dataclasses import dataclass
 
 from evidently.options import OptionsProvider
 from evidently.pipeline.column_mapping import ColumnMapping
+from evidently.analyzers.utils import DatasetColumns
+
+
+@dataclass
+class BaseAnalyzerResult:
+    """Base class for all analyzers results.
+
+    If you want to add a new analyzer, inherit a results class from the class.
+    For correct initiation you should add a decorator `@dataclass` to children classes too.
+
+        For example:
+
+        @dataclass
+        class RegressionPerformanceAnalyzerResults(BaseAnalyzerResult):
+            my_result: str
+    """
+    columns: DatasetColumns
 
 
 class Analyzer:
@@ -14,7 +32,7 @@ class Analyzer:
     def calculate(self,
                   reference_data: pd.DataFrame,
                   current_data: Optional[pd.DataFrame],
-                  column_mapping: ColumnMapping) -> object:
+                  column_mapping: ColumnMapping) -> BaseAnalyzerResult:
         raise NotImplementedError()
 
     options_provider: OptionsProvider

--- a/src/evidently/analyzers/cat_target_drift_analyzer.py
+++ b/src/evidently/analyzers/cat_target_drift_analyzer.py
@@ -8,8 +8,9 @@ from dataclasses import dataclass
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
+from evidently.analyzers.base_analyzer import BaseAnalyzerResult
 from evidently.analyzers.stattests import z_stat_test, chi_stat_test
-from evidently.analyzers.utils import process_columns, DatasetColumns
+from evidently.analyzers.utils import process_columns
 from evidently.options import DataDriftOptions
 
 
@@ -38,9 +39,8 @@ class DataDriftMetrics:
 
 
 @dataclass
-class CatTargetDriftAnalyzerResults:
+class CatTargetDriftAnalyzerResults(BaseAnalyzerResult):
     """Class for all results of category target drift calculations"""
-    columns: DatasetColumns
     target_metrics: Optional[DataDriftMetrics] = None
     prediction_metrics: Optional[DataDriftMetrics] = None
 

--- a/src/evidently/analyzers/classification_performance_analyzer.py
+++ b/src/evidently/analyzers/classification_performance_analyzer.py
@@ -11,7 +11,8 @@ from sklearn import metrics
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
-from evidently.analyzers.utils import process_columns, DatasetColumns
+from evidently.analyzers.base_analyzer import BaseAnalyzerResult
+from evidently.analyzers.utils import process_columns
 
 
 @dataclass
@@ -32,8 +33,7 @@ class PerformanceMetrics:
 
 
 @dataclass
-class ClassificationPerformanceAnalyzerResults:
-    columns: DatasetColumns
+class ClassificationPerformanceAnalyzerResults(BaseAnalyzerResult):
     reference_metrics: Optional[PerformanceMetrics] = None
     current_metrics: Optional[PerformanceMetrics] = None
 

--- a/src/evidently/analyzers/num_target_drift_analyzer.py
+++ b/src/evidently/analyzers/num_target_drift_analyzer.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
+from evidently.analyzers.base_analyzer import BaseAnalyzerResult
 from evidently.options import DataDriftOptions
 from evidently.analyzers.stattests import ks_stat_test
 from evidently.analyzers.utils import process_columns
-from evidently.analyzers.utils import DatasetColumns
 from typing import List, Callable
 
 
@@ -58,8 +58,7 @@ def _compute_correlation(
 
 
 @dataclass
-class NumTargetDriftAnalyzerResults:
-    columns: DatasetColumns
+class NumTargetDriftAnalyzerResults(BaseAnalyzerResult):
     target_metrics: Optional[NumDataDriftMetrics] = None
     prediction_metrics: Optional[NumDataDriftMetrics] = None
 

--- a/src/evidently/analyzers/prob_classification_performance_analyzer.py
+++ b/src/evidently/analyzers/prob_classification_performance_analyzer.py
@@ -11,9 +11,9 @@ from sklearn import metrics
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
+from evidently.analyzers.base_analyzer import BaseAnalyzerResult
 from evidently.options import QualityMetricsOptions
 from evidently.analyzers.utils import process_columns
-from evidently.analyzers.utils import DatasetColumns
 
 
 @dataclass
@@ -40,8 +40,7 @@ class ClassificationPerformanceMetrics:
 
 
 @dataclass
-class ProbClassificationPerformanceAnalyzerResults:
-    columns: DatasetColumns
+class ProbClassificationPerformanceAnalyzerResults(BaseAnalyzerResult):
     quality_metrics_options: QualityMetricsOptions
     reference_metrics: Optional[ClassificationPerformanceMetrics] = None
     current_metrics: Optional[ClassificationPerformanceMetrics] = None

--- a/src/evidently/analyzers/regression_performance_analyzer.py
+++ b/src/evidently/analyzers/regression_performance_analyzer.py
@@ -9,8 +9,8 @@ from scipy.stats import probplot
 
 from evidently import ColumnMapping
 from evidently.analyzers.base_analyzer import Analyzer
+from evidently.analyzers.base_analyzer import BaseAnalyzerResult
 from evidently.analyzers.utils import process_columns
-from evidently.analyzers.utils import DatasetColumns
 
 
 class ErrorWithQuantiles:
@@ -50,8 +50,7 @@ class RegressionPerformanceMetrics:
 
 
 @dataclass
-class RegressionPerformanceAnalyzerResults:
-    columns: DatasetColumns
+class RegressionPerformanceAnalyzerResults(BaseAnalyzerResult):
     reference_metrics: Optional[RegressionPerformanceMetrics] = None
     current_metrics: Optional[RegressionPerformanceMetrics] = None
     error_bias: Optional[dict] = None

--- a/src/evidently/dashboard/widgets/data_drift_table_widget.py
+++ b/src/evidently/dashboard/widgets/data_drift_table_widget.py
@@ -27,8 +27,8 @@ class DataDriftTableWidget(Widget):
                   column_mapping: ColumnMapping,
                   analyzers_results) -> Optional[BaseWidgetInfo]:
         data_drift_results = DataDriftAnalyzer.get_results(analyzers_results)
-        all_features = data_drift_results.get_all_features_list()
-        date_column = data_drift_results.utility_columns.date
+        all_features = data_drift_results.columns.get_all_features_list(cat_before_num=True)
+        date_column = data_drift_results.columns.utility_columns.date
 
         if current_data is None:
             raise ValueError("current_data should be present")

--- a/src/evidently/model_monitoring/monitors/data_drift.py
+++ b/src/evidently/model_monitoring/monitors/data_drift.py
@@ -22,7 +22,7 @@ class DataDriftMonitor(ModelMonitor):
         yield DataDriftMetrics.n_drifted_features.create(data_drift_results.metrics.n_drifted_features)
         yield DataDriftMetrics.dataset_drift.create(data_drift_results.metrics.dataset_drift)
 
-        for feature_name in data_drift_results.get_all_features_list():
+        for feature_name in data_drift_results.columns.get_all_features_list(cat_before_num=True):
             feature_metric = data_drift_results.metrics.features[feature_name]
             yield DataDriftMetrics.p_value.create(
                 feature_metric.p_value,

--- a/src/evidently/model_profile/sections/data_drift_profile_section.py
+++ b/src/evidently/model_profile/sections/data_drift_profile_section.py
@@ -40,10 +40,10 @@ class DataDriftProfileSection(ProfileSection):
             'name': self.part_id(),
             'datetime': str(datetime.now()),
             'data': {
-                'utility_columns': data_drift_results.utility_columns.as_dict(),
-                'cat_feature_names': data_drift_results.cat_feature_names,
-                'num_feature_names': data_drift_results.num_feature_names,
-                'target_names': data_drift_results.target_names,
+                'utility_columns': data_drift_results.columns.utility_columns.as_dict(),
+                'cat_feature_names': data_drift_results.columns.cat_feature_names,
+                'num_feature_names': data_drift_results.columns.num_feature_names,
+                'target_names': data_drift_results.columns.target_names,
                 'options': data_drift_results.options.as_dict(),
                 'metrics': metrics_dict
             }

--- a/tests/analyzers/test_data_drift_analyzer.py
+++ b/tests/analyzers/test_data_drift_analyzer.py
@@ -31,14 +31,11 @@ def test_data_drift_analyzer_as_dict_format(data_drift_analyzer: DataDriftAnalyz
     data_columns.target_names = ['drift_target']
     result = data_drift_analyzer.calculate(test_data[:2], test_data, data_columns)
     assert result.options is not None
-    assert result.utility_columns is not None
+    assert result.columns is not None
     # check features in results
     assert result.metrics.n_features == 4
-    assert result.cat_feature_names == ['categorical_feature_1', 'categorical_feature_2']
-    assert result.num_feature_names == ['numerical_feature_1', 'numerical_feature_2']
-    assert result.get_all_features_list() == [
-        'categorical_feature_1', 'categorical_feature_2', 'numerical_feature_1', 'numerical_feature_2'
-    ]
+    assert result.columns.cat_feature_names == ['categorical_feature_1', 'categorical_feature_2']
+    assert result.columns.num_feature_names == ['numerical_feature_1', 'numerical_feature_2']
     assert 'numerical_feature_1' in result.metrics.features
     assert 'numerical_feature_2' in result.metrics.features
     assert 'categorical_feature_1' in result.metrics.features
@@ -46,5 +43,5 @@ def test_data_drift_analyzer_as_dict_format(data_drift_analyzer: DataDriftAnalyz
     assert 'numerical_feature_3' not in result.metrics.features
 
     # check data drift results
-    assert result.target_names == ['drift_target']
+    assert result.columns.target_names == ['drift_target']
     assert result.metrics.dataset_drift is False

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -121,7 +121,6 @@ def test_regression_performance_single_frame_dashboard(iris_frame) -> None:
     assert len(actual['widgets']) == 11
 
 
-
 def test_classification_performance_dashboard(iris_frame) -> None:
     # To generate the **Classification Model Performance** report, run:
     # FIXME: when prediction column is not present in the dataset


### PR DESCRIPTION
- add BaseAnalyzerResult with common for all analysers `columns: DatasetColumns` field
- move columns calculations from DataDriftAnalyzer to DatasetColumns common code
- move `current_data` check to the beginning of DataDriftAnalyzer.calculate method
- small fix for `flake8 tests`