### PR TITLE
Add num and cat target drift monitors

### DIFF
--- a/src/evidently/analyzers/cat_target_drift_analyzer.py
+++ b/src/evidently/analyzers/cat_target_drift_analyzer.py
@@ -43,6 +43,8 @@ class CatTargetDriftAnalyzerResults(BaseAnalyzerResult):
     """Class for all results of category target drift calculations"""
     target_metrics: Optional[DataDriftMetrics] = None
     prediction_metrics: Optional[DataDriftMetrics] = None
+    reference_data_count: int = 0
+    current_data_count: int = 0
 
 
 class CatTargetDriftAnalyzer(Analyzer):
@@ -99,7 +101,9 @@ class CatTargetDriftAnalyzer(Analyzer):
 
         options = self.options_provider.get(DataDriftOptions)
         columns = process_columns(reference_data, column_mapping)
-        result = CatTargetDriftAnalyzerResults(columns=columns)
+        result = CatTargetDriftAnalyzerResults(
+            columns=columns, reference_data_count=reference_data.shape[0], current_data_count=reference_data.shape[0]
+        )
         target_column = columns.utility_columns.target
         prediction_column = columns.utility_columns.prediction
 

--- a/src/evidently/analyzers/num_target_drift_analyzer.py
+++ b/src/evidently/analyzers/num_target_drift_analyzer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
+from typing import Dict
 from typing import Optional
 
 import pandas as pd
@@ -16,10 +17,10 @@ from typing import List, Callable
 
 @dataclass
 class NumDataDriftMetrics:
-    """Class for drift values"""
+    """Class numeric features drift values"""
     column_name: str
-    reference_correlations: dict
-    current_correlations: dict
+    reference_correlations: Dict[str, float]
+    current_correlations: Dict[str, float]
     drift: float
 
 
@@ -40,15 +41,9 @@ def _compute_correlation(
         raise ValueError(f'Column {main_column} should only contain numerical values.')
 
     target_p_value = stats_fun(reference_data[main_column], current_data[main_column])
-    metrics = {
-        prefix + '_name': main_column,
-        prefix + '_type': 'num',
-        prefix + '_drift': target_p_value
-    }
     ref_target_corr = reference_data[num_columns + [main_column]].corr()[main_column]
     curr_target_corr = current_data[num_columns + [main_column]].corr()[main_column]
-    target_corr = {'reference': ref_target_corr.to_dict(), 'current': curr_target_corr.to_dict()}
-    metrics[prefix + '_correlations'] = target_corr
+
     return NumDataDriftMetrics(
         column_name=main_column,
         reference_correlations=ref_target_corr.to_dict(),
@@ -59,6 +54,8 @@ def _compute_correlation(
 
 @dataclass
 class NumTargetDriftAnalyzerResults(BaseAnalyzerResult):
+    reference_data_count: int = 0
+    current_data_count: int = 0
     target_metrics: Optional[NumDataDriftMetrics] = None
     prediction_metrics: Optional[NumDataDriftMetrics] = None
 
@@ -108,16 +105,22 @@ class NumTargetDriftAnalyzer(Analyzer):
         Raises:
             ValueError when target or predictions columns are not numerical.
         """
-        data_drift_options = self.options_provider.get(DataDriftOptions)
-        columns = process_columns(reference_data, column_mapping)
-        result = NumTargetDriftAnalyzerResults(columns=columns)
+        if reference_data is None:
+            raise ValueError("reference_data should not be None")
 
         if current_data is None:
             raise ValueError("current_data should not be None")
 
+        columns = process_columns(reference_data, column_mapping)
+
         if set(columns.num_feature_names) - set(current_data.columns):
             raise ValueError(f'Some numerical features in current data {current_data.columns}'
                              f'are not present in columns.num_feature_names')
+
+        result = NumTargetDriftAnalyzerResults(
+            columns=columns, reference_data_count=reference_data.shape[0], current_data_count=reference_data.shape[0]
+        )
+        data_drift_options = self.options_provider.get(DataDriftOptions)
 
         func = data_drift_options.num_target_stattest_func or ks_stat_test
         result.target_metrics = _compute_correlation(

--- a/src/evidently/model_monitoring/__init__.py
+++ b/src/evidently/model_monitoring/__init__.py
@@ -1,4 +1,6 @@
 from .monitoring import ModelMonitoring
+from .monitors.cat_target_drift import CatTargetDriftMonitor
+from .monitors.num_target_drift import NumTargetDriftMonitor
 from .monitors.data_drift import DataDriftMonitor
 from .monitors.regression_performance import RegressionPerformanceMonitor
 from .monitors.classification_performance import ClassificationPerformanceMonitor

--- a/src/evidently/model_monitoring/monitors/cat_target_drift.py
+++ b/src/evidently/model_monitoring/monitors/cat_target_drift.py
@@ -1,0 +1,32 @@
+from typing import Generator
+
+from evidently.analyzers import cat_target_drift_analyzer
+from evidently.model_monitoring import monitoring
+
+
+class CatTargetDriftMonitorMetrics:
+    _tag = 'cat_target_drift'
+    drift = monitoring.ModelMonitoringMetric(f'{_tag}:drift', ['feature', 'feature_type', 'kind'])
+
+
+class NumTargetDriftMonitor(monitoring.ModelMonitor):
+    def monitor_id(self) -> str:
+        return 'cat_target_drift'
+
+    def analyzers(self):
+        return [cat_target_drift_analyzer.CatTargetDriftAnalyzer]
+
+    def metrics(self, analyzer_results) -> Generator[monitoring.MetricsType, None, None]:
+        results = cat_target_drift_analyzer.CatTargetDriftAnalyzer.get_results(analyzer_results)
+
+        if results.prediction_metrics:
+            yield CatTargetDriftMonitorMetrics.drift.create(
+                results.prediction_metrics.drift,
+                dict(feature=results.prediction_metrics.column_name, feature_type='cat', kind='prediction')
+            )
+
+        if results.target_metrics:
+            yield CatTargetDriftMonitorMetrics.drift.create(
+                results.target_metrics.drift,
+                dict(feature=results.target_metrics.column_name, feature_type='cat', kind='target')
+            )

--- a/src/evidently/model_monitoring/monitors/cat_target_drift.py
+++ b/src/evidently/model_monitoring/monitors/cat_target_drift.py
@@ -5,11 +5,18 @@ from evidently.model_monitoring import monitoring
 
 
 class CatTargetDriftMonitorMetrics:
+    """Class for category target grift metrics.
+
+    Metrics list:
+        - count: quantity of rows in `reference` and `current` datasets
+        - drift: p_value for the data drift
+    """
     _tag = 'cat_target_drift'
-    drift = monitoring.ModelMonitoringMetric(f'{_tag}:drift', ['feature', 'feature_type', 'kind'])
+    count = monitoring.ModelMonitoringMetric(f'{_tag}:count', ['dataset'])
+    drift = monitoring.ModelMonitoringMetric(f'{_tag}:drift', ['kind'])
 
 
-class NumTargetDriftMonitor(monitoring.ModelMonitor):
+class CatTargetDriftMonitor(monitoring.ModelMonitor):
     def monitor_id(self) -> str:
         return 'cat_target_drift'
 
@@ -19,14 +26,12 @@ class NumTargetDriftMonitor(monitoring.ModelMonitor):
     def metrics(self, analyzer_results) -> Generator[monitoring.MetricsType, None, None]:
         results = cat_target_drift_analyzer.CatTargetDriftAnalyzer.get_results(analyzer_results)
 
+        # quantity of rows in income data
+        yield CatTargetDriftMonitorMetrics.count.create(results.reference_data_count, dict(dataset='prediction'))
+        yield CatTargetDriftMonitorMetrics.count.create(results.current_data_count, dict(dataset='current'))
+
         if results.prediction_metrics:
-            yield CatTargetDriftMonitorMetrics.drift.create(
-                results.prediction_metrics.drift,
-                dict(feature=results.prediction_metrics.column_name, feature_type='cat', kind='prediction')
-            )
+            yield CatTargetDriftMonitorMetrics.drift.create(results.prediction_metrics.drift, dict(kind='prediction'))
 
         if results.target_metrics:
-            yield CatTargetDriftMonitorMetrics.drift.create(
-                results.target_metrics.drift,
-                dict(feature=results.target_metrics.column_name, feature_type='cat', kind='target')
-            )
+            yield CatTargetDriftMonitorMetrics.drift.create(results.target_metrics.drift, dict(kind='target'))

--- a/src/evidently/model_monitoring/monitors/num_target_drift.py
+++ b/src/evidently/model_monitoring/monitors/num_target_drift.py
@@ -5,6 +5,16 @@ from evidently.model_monitoring import monitoring
 
 
 class NumTargetDriftMonitorMetrics:
+    """Class for numeric target grift metrics.
+
+    Metrics list:
+        - count: quantity of rows in `reference` and `current` datasets
+        - drift: p_value for the data drift
+        - current_correlations: correlation with `target` and `prediction` columns
+            for numeric features in `current` dataset
+        - reference_correlations: correlation with `target` and `prediction` columns
+            for numeric features in `reference` dataset
+    """
     _tag = 'num_target_drift'
     count = monitoring.ModelMonitoringMetric(f'{_tag}:count', ['dataset'])
     drift = monitoring.ModelMonitoringMetric(f'{_tag}:drift', ['kind'])

--- a/src/evidently/model_monitoring/monitors/num_target_drift.py
+++ b/src/evidently/model_monitoring/monitors/num_target_drift.py
@@ -1,0 +1,30 @@
+from evidently.analyzers import num_target_drift_analyzer
+from evidently.model_monitoring import monitoring
+
+
+class NumTargetDriftMonitorMetrics:
+    _tag = 'num_target_drift'
+    drift = monitoring.ModelMonitoringMetric(f'{_tag}:drift', ['kind'])
+
+
+class NumTargetDriftMonitor(monitoring.ModelMonitor):
+    def monitor_id(self) -> str:
+        return 'num_target_drift'
+
+    def analyzers(self):
+        return [num_target_drift_analyzer.NumTargetDriftAnalyzer]
+
+    def metrics(self, analyzer_results):
+        results = num_target_drift_analyzer.NumTargetDriftAnalyzer.get_results(analyzer_results)
+
+        if results.prediction_metrics:
+            yield NumTargetDriftMonitorMetrics.drift.create(
+                results.prediction_metrics.drift,
+                dict(feature=results.prediction_metrics.column_name, feature_type='cat', kind='prediction')
+            )
+
+        if results.target_metrics:
+            yield NumTargetDriftMonitorMetrics.drift.create(
+                results.target_metrics.drift,
+                dict(feature=results.target_metrics.column_name, feature_type='cat', kind='target')
+            )

--- a/src/evidently/model_monitoring/monitors/num_target_drift.py
+++ b/src/evidently/model_monitoring/monitors/num_target_drift.py
@@ -1,10 +1,19 @@
+from typing import Generator
+
 from evidently.analyzers import num_target_drift_analyzer
 from evidently.model_monitoring import monitoring
 
 
 class NumTargetDriftMonitorMetrics:
     _tag = 'num_target_drift'
+    count = monitoring.ModelMonitoringMetric(f'{_tag}:count', ['dataset'])
     drift = monitoring.ModelMonitoringMetric(f'{_tag}:drift', ['kind'])
+    current_correlations = monitoring.ModelMonitoringMetric(
+        f'{_tag}:current_correlations', ['feature', 'feature_type', 'kind']
+    )
+    reference_correlations = monitoring.ModelMonitoringMetric(
+        f'{_tag}:reference_correlations', ['feature', 'feature_type', 'kind']
+    )
 
 
 class NumTargetDriftMonitor(monitoring.ModelMonitor):
@@ -14,17 +23,34 @@ class NumTargetDriftMonitor(monitoring.ModelMonitor):
     def analyzers(self):
         return [num_target_drift_analyzer.NumTargetDriftAnalyzer]
 
+    @staticmethod
+    def _yield_metrics(
+            metrics: num_target_drift_analyzer.NumDataDriftMetrics,
+            kind: str
+    ) -> Generator[monitoring.MetricsType, None, None]:
+        yield NumTargetDriftMonitorMetrics.drift.create(metrics.drift, dict(kind=kind))
+
+        for feature_name, correlation_value in metrics.reference_correlations.items():
+            yield NumTargetDriftMonitorMetrics.reference_correlations.create(
+                correlation_value, dict(feature=feature_name, feature_type='num', kind=kind)
+            )
+
+        for feature_name, correlation_value in metrics.current_correlations.items():
+            yield NumTargetDriftMonitorMetrics.current_correlations.create(
+                correlation_value, dict(feature=feature_name, feature_type='num', kind=kind)
+            )
+
     def metrics(self, analyzer_results):
         results = num_target_drift_analyzer.NumTargetDriftAnalyzer.get_results(analyzer_results)
 
+        # quantity of rows in income data
+        yield NumTargetDriftMonitorMetrics.count.create(results.reference_data_count, dict(dataset='prediction'))
+        yield NumTargetDriftMonitorMetrics.count.create(results.current_data_count, dict(dataset='current'))
+
         if results.prediction_metrics:
-            yield NumTargetDriftMonitorMetrics.drift.create(
-                results.prediction_metrics.drift,
-                dict(feature=results.prediction_metrics.column_name, feature_type='cat', kind='prediction')
-            )
+            for metric in self._yield_metrics(metrics=results.prediction_metrics, kind='prediction'):
+                yield metric
 
         if results.target_metrics:
-            yield NumTargetDriftMonitorMetrics.drift.create(
-                results.target_metrics.drift,
-                dict(feature=results.target_metrics.column_name, feature_type='cat', kind='target')
-            )
+            for metric in self._yield_metrics(metrics=results.target_metrics, kind='target'):
+                yield metric

--- a/tests/model_monitoring/test_model_monitoring.py
+++ b/tests/model_monitoring/test_model_monitoring.py
@@ -22,13 +22,21 @@ def _collect_metrics_results(metrics: Generator[monitoring.MetricsType, None, No
 
 
 def test_model_monitoring_with_simple_data():
-    test_data = pd.DataFrame({
+    reference_data = pd.DataFrame({
         'target': [1, 2, 3, 4, 5],
-        'prediction': [5, 4, 3, 2, 1],
+        'prediction': [1, 2, 7, 2, 1],
         'numerical_feature_1': [0.5, 0.0, 4.8, 2.1, 4.2],
         'numerical_feature_2': [0, 5, 6, 3, 6],
         'categorical_feature_1': [1, 1, 0, 1, 0],
         'categorical_feature_2': [0, 1, 0, 0, 0],
+    })
+    current_data = pd.DataFrame({
+        'target': [5, 4, 3, 2, 1],
+        'prediction': [1, 7, 2, 7, 1],
+        'numerical_feature_1': [0.6, 0.1, 45.3, 2.6, 4.2],
+        'numerical_feature_2': [0, 5, 3, 7, 6],
+        'categorical_feature_1': [1, 0, 1, 1, 0],
+        'categorical_feature_2': [0, 1, 0, 1, 1],
     })
     mapping = column_mapping.ColumnMapping(
         categorical_features=['categorical_feature_1', 'categorical_feature_2'],
@@ -36,15 +44,24 @@ def test_model_monitoring_with_simple_data():
     )
     evidently_monitoring = model_monitoring.ModelMonitoring(
         monitors=[
+            model_monitoring.CatTargetDriftMonitor(),
+            model_monitoring.NumTargetDriftMonitor(),
+            model_monitoring.DataDriftMonitor(),
             model_monitoring.DataDriftMonitor(),
             model_monitoring.RegressionPerformanceMonitor(),
             model_monitoring.ClassificationPerformanceMonitor(),
         ],
         options=None,
     )
-    evidently_monitoring.execute(test_data, test_data, column_mapping=mapping)
+    evidently_monitoring.execute(reference_data=reference_data, current_data=current_data, column_mapping=mapping)
     result = _collect_metrics_results(evidently_monitoring.metrics())
 
+    assert 'cat_target_drift:count' in result
+    assert 'cat_target_drift:drift' in result
+    assert 'num_target_drift:count' in result
+    assert 'num_target_drift:drift' in result
+    assert 'num_target_drift:current_correlations' in result
+    assert 'num_target_drift:reference_correlations' in result
     assert 'data_drift:dataset_drift' in result
     assert 'data_drift:n_drifted_features' in result
     assert 'data_drift:p_value' in result

--- a/tests/model_monitoring/test_model_monitoring.py
+++ b/tests/model_monitoring/test_model_monitoring.py
@@ -47,7 +47,6 @@ def test_model_monitoring_with_simple_data():
             model_monitoring.CatTargetDriftMonitor(),
             model_monitoring.NumTargetDriftMonitor(),
             model_monitoring.DataDriftMonitor(),
-            model_monitoring.DataDriftMonitor(),
             model_monitoring.RegressionPerformanceMonitor(),
             model_monitoring.ClassificationPerformanceMonitor(),
         ],


### PR DESCRIPTION
- add `CatTargetDriftMonitor` implementation with metrics: drift and rows count
- add `NumTargetDriftMonitor` implementation with metrics: drift, rows count, correlation for numeric features
- add the monitors to all monitors tests

For count/quantity metric implementation:
- add reference/current data rows counting in `CatTargetDriftAnalyzerResults` and `NumTargetDriftAnalyzerResults`

Additional changes:
- remove useless metrics dict creation in compute correlation method in numeric target drift analyzer file
- update NumDataDriftMetrics description and typing
- add tests for NumTargetDriftAnalyzer for cases with not enough data