### PR TITLE
fix data load to monitoring service script + add some docs and comments

### DIFF
--- a/examples/integrations/grafana_monitoring_service/app.py
+++ b/examples/integrations/grafana_monitoring_service/app.py
@@ -1,4 +1,14 @@
+"""
+This is a demo service for Evidently metrics integration with Prometheus and Grafana.
+
+Read `README.md` for proper setup and installation.
+
+The service gets a reference dataset from reference.csv file and process current data with HTTP API.
+
+Metrics calculation results are available with `GET /metrics` HTTP method in Prometheus compatible format.
+"""
 import hashlib
+import os.path
 
 import dataclasses
 import datetime
@@ -15,17 +25,18 @@ from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from evidently import model_monitoring
 from evidently.pipeline.column_mapping import ColumnMapping
-from evidently.model_monitoring import DataDriftMonitor, RegressionPerformanceMonitor,\
-    ClassificationPerformanceMonitor,\
-    ProbClassificationPerformanceMonitor
+from evidently.model_monitoring import (
+    DataDriftMonitor,
+    RegressionPerformanceMonitor,
+    ClassificationPerformanceMonitor,
+    ProbClassificationPerformanceMonitor,
+)
 from evidently.runner.loader import DataLoader, DataOptions
 
 app = Flask(__name__)
 logger = create_logger(app)
 # Add prometheus wsgi middleware to route /metrics requests
-app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
-    '/metrics': make_wsgi_app()
-})
+app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {"/metrics": make_wsgi_app()})
 
 
 @dataclasses.dataclass
@@ -51,16 +62,16 @@ class MonitoringService:
     metric: Dict[str, Gauge]
     last_run: Optional[datetime.datetime]
 
-    def __init__(self,
-                 reference: pandas.DataFrame,
-                 options: MonitoringServiceOptions,
-                 column_mapping: ColumnMapping = None):
-        self.monitoring = model_monitoring.ModelMonitoring(monitors=[monitor_mapping[k]() for k in options.monitors],
-                                                           options=[])
+    def __init__(
+        self, reference: pandas.DataFrame, options: MonitoringServiceOptions, column_mapping: ColumnMapping = None
+    ):
+        self.monitoring = model_monitoring.ModelMonitoring(
+            monitors=[monitor_mapping[k]() for k in options.monitors], options=[]
+        )
 
         if options.use_reference:
-            self.reference = reference.iloc[:-options.window_size, :].copy()
-            self.current = reference.iloc[-options.window_size:, :].copy()
+            self.reference = reference.iloc[: -options.window_size, :].copy()
+            self.current = reference.iloc[-options.window_size :, :].copy()
         else:
             self.reference = reference.copy()
             self.current = pandas.DataFrame().reindex_like(reference).dropna()
@@ -84,8 +95,9 @@ class MonitoringService:
             self.current.reset_index(drop=True, inplace=True)
 
         if current_size < self.options.window_size:
-            logger.info(f"Not enough data for measurement: {current_size} of {self.options.window_size}."
-                        f" Waiting more data")
+            logger.info(
+                f"Not enough data for measurement: {current_size} of {self.options.window_size}." f" Waiting more data"
+            )
             return
         if self.next_run_time is not None and self.next_run_time > datetime.datetime.now():
             logger.info(f"Next run at {self.next_run_time}")
@@ -112,23 +124,33 @@ SERVICE: Optional[MonitoringService] = None
 def configure_service():
     # pylint: disable=global-statement
     global SERVICE
-    with open("config.yaml", 'rb') as config_file:
+    config_file_name = "config.yaml"
+    # try to find a config file, it should be generated via a data preparation script
+    if not os.path.exists(config_file_name):
+        exit("Cannot find config file for the metrics service. Try to check README.md for setup instructions.")
+
+    with open(config_file_name, "rb") as config_file:
         config = yaml.safe_load(config_file)
+
     loader = DataLoader()
     logger.info(f"config: {config}")
-    options = MonitoringServiceOptions(**config['service'])
+    options = MonitoringServiceOptions(**config["service"])
 
-    reference_data = loader.load(options.reference_path,
-                                 DataOptions(date_column=config['data_format'].get('date_column', None),
-                                             separator=config['data_format']['separator'],
-                                             header=config['data_format']['header']))
+    reference_data = loader.load(
+        options.reference_path,
+        DataOptions(
+            date_column=config["data_format"].get("date_column", None),
+            separator=config["data_format"]["separator"],
+            header=config["data_format"]["header"],
+        ),
+    )
     logger.info(f"reference dataset loaded: {len(reference_data)} rows")
-    SERVICE = MonitoringService(reference_data,
-                                options=options,
-                                column_mapping=ColumnMapping(**config['column_mapping']))
+    SERVICE = MonitoringService(
+        reference_data, options=options, column_mapping=ColumnMapping(**config["column_mapping"])
+    )
 
 
-@app.route('/iterate', methods=["POST"])
+@app.route("/iterate", methods=["POST"])
 def iterate():
     item = flask.request.json
     if SERVICE is None:
@@ -137,5 +159,5 @@ def iterate():
     return "ok"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run()

--- a/examples/integrations/grafana_monitoring_service/example_run_request.py
+++ b/examples/integrations/grafana_monitoring_service/example_run_request.py
@@ -1,28 +1,69 @@
+#!/usr/bin/env python3
+
 import argparse
+import json
 import os
 import time
 
-import csv
+import numpy as np
+import pandas as pd
 import requests
 
 
-def main(csv_file_path):
-    print("Start send the data to the monitoring service one by one.")
-    with open(csv_file_path, encoding='utf-8') as csv_file:
-        production_data = csv.DictReader(csv_file)
+# the encoder helps to convert NumPy types in source data to JSON-compatible types
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.void):
+            return None
 
-        for data in production_data:
-            print("Send a data item")
-            requests.post("http://127.0.0.1:5000/iterate", data=data, headers={"content-type": "application/json"})
-            print("Done.")
-            time.sleep(10)
+        if isinstance(obj, (np.generic, np.bool_)):
+            return obj.item()
+
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+
+        return obj
+
+
+def main(csv_file_path, sleep_timeout: int) -> None:
+    print("Start send the data to the monitoring service one by one.")
+    new_data = pd.read_csv(csv_file_path)
+
+    for idx in range(0, new_data.shape[0]):
+        data = new_data.iloc[idx].to_dict()
+        print("Send a data item")
+
+        response = requests.post(
+            "http://localhost:5000/iterate",
+            data=json.dumps([data], cls=NumpyEncoder),
+            headers={"content-type": "application/json"},
+        )
+
+        if response.status_code == 200:
+            print(f"Success.")
+
+        else:
+            print(
+                f"Got an error code {response.status_code} for the data chunk. "
+                f"Reason: {response.reason}, error text: {response.text}"
+            )
+
+        print(f"Wait {sleep_timeout} seconds till the next try.")
+        time.sleep(sleep_timeout)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Script for data and config generation for demo Evidently metrics integration with Grafana"
+        description="Script for data sending to Evidently metrics integration demo service"
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=10,
+        help="Sleep timeout between data send tries in seconds.",
     )
     args = parser.parse_args()
     production_data_file = os.path.abspath("production.csv")
     print("Get production data from {production_data_file} and send it to monitoring service each 10 seconds")
-    main(production_data_file)
+    main(production_data_file, args.timeout)

--- a/examples/integrations/grafana_monitoring_service/requirements.txt
+++ b/examples/integrations/grafana_monitoring_service/requirements.txt
@@ -1,3 +1,4 @@
+numpy~=1.19.5
 pandas~=1.1.5
 pyyaml~=5.4.1
 requests~=2.27.1


### PR DESCRIPTION
- fix data load script in Grafana integration example: use pandas back instead of csv module - pandas process data types better
- add timeout option for the data load script
- add some comments with links to README.md to monitoring service file `app.py`
- apply black formatting for app.py