### PR TITLE
Replace feature_stattest_func with new options.

### DIFF
--- a/docs/book/customization/options-for-statistical-tests.md
+++ b/docs/book/customization/options-for-statistical-tests.md
@@ -6,13 +6,18 @@ description: You can modify the statistical tests used to calculate Data and Tar
 
 ## Available Options
 
-- `feature_stattest_func` (default: `None`): define the Statistical Test for features in the DataDrift Dashboard or Profile:
+- (deprecated)`feature_stattest_func` (default: `None`): define the Statistical Test for features in the DataDrift Dashboard or Profile:
   - `None` - use default Statistical Tests for all features (based on internal logic)
   - You can define a Statistical Test to be used for all the features in the dataset:
     - `str` - the name of StatTest to use across all features (see the available names below)
     - `Callable[[pd.Series, pd.Series, str, float], Tuple[float, bool]]` - custom StatTest function added (see the requirements for the custom StatTest function below)
     - `StatTest` - an instance of `StatTest`
-  - You can define a Statistical Test to be used for individual features by passing a `dict` object where the key is a feature name and the value is one from the previous options (`str`, `Callable` or `StatTest`)  
+  - You can define a Statistical Test to be used for individual features by passing a `dict` object where the key is a feature name and the value is one from the previous options (`str`, `Callable` or `StatTest`)
+  - **Deprecated:** Use `all_features_stattest` or `per_feature_statttest` options.
+- `all_features_stattest`(default: `None`): defines a custom statistical test for all features in DataDrift Dashboard or Profile.
+- `cat_features_stattest` (default: `None`): defines a custom statistical test for categorical features in DataDrift Dashboard or Profile.
+- `num_features_stattest` (default: `None`): defines a custom statistical test for numerical features in DataDrift Dashboard or Profile.
+- `per_feature_stattest` (default: `None`): defines a custom statistical test per feature in DataDrift Dashboard or Profile as `dict` object where key is feature name and values is statistical test. 
 - `cat_target_stattest_func` (default: `None`): defines a custom statistical test to detect target drift in the Categorical Target Drift report. It follows the same logic as the `feature_stattest_func`, but without the `dict` option. 
 - `num_target_stattest_func` (default: `None`): defines a custom statistical test to detect target drift in the Numerical Target Drift report. It follows the same logic as the `feature_stattest_func`, but without the `dict` option. 
 

--- a/src/evidently/analyzers/data_drift_analyzer.py
+++ b/src/evidently/analyzers/data_drift_analyzer.py
@@ -74,7 +74,8 @@ class DataDriftAnalyzer(Analyzer):
         for feature_name in num_feature_names:
             threshold = data_drift_options.get_threshold(feature_name)
             feature_type = "num"
-            test = get_stattest(data_drift_options.get_feature_stattest_func(feature_name, ks_stat_test), feature_type)
+            test = get_stattest(data_drift_options.get_feature_stattest_func(feature_name, feature_type, ks_stat_test),
+                                feature_type)
             p_value, drifted = test.func(reference_data[feature_name],
                                          current_data[feature_name],
                                          feature_type,
@@ -102,8 +103,13 @@ class DataDriftAnalyzer(Analyzer):
                        list(feature_cur_data.unique())) - {np.nan}
             default_test = chi_stat_test if len(keys) > 2 else z_stat_test
             feature_type = "cat"
-            stat_test = get_stattest(data_drift_options.get_feature_stattest_func(feature_name, default_test),
-                                     feature_type)
+            stat_test = get_stattest(
+                data_drift_options.get_feature_stattest_func(
+                    feature_name,
+                    feature_type,
+                    default_test
+                ),
+                feature_type)
             p_value, drifted = stat_test.func(feature_ref_data, feature_cur_data, feature_type, threshold)
 
             p_values[feature_name] = PValueWithDrift(p_value, drifted)

--- a/src/evidently/options/data_drift.py
+++ b/src/evidently/options/data_drift.py
@@ -16,7 +16,14 @@ class DataDriftOptions:
     drift_share: float = 0.5
     nbinsx: Union[int, Dict[str, int]] = DEFAULT_NBINSX
     xbins: Optional[Dict[str, int]] = None
+
     feature_stattest_func: Optional[Union[PossibleStatTestType, Dict[str, PossibleStatTestType]]] = None
+
+    stattest: Optional[PossibleStatTestType] = None
+    cat_stattest: Optional[PossibleStatTestType] = None
+    num_stattest: Optional[PossibleStatTestType] = None
+    per_feature_stattest: Optional[Dict[str, PossibleStatTestType]] = None
+
     cat_target_stattest_func: Optional[PossibleStatTestType] = None
     num_target_stattest_func: Optional[PossibleStatTestType] = None
 
@@ -53,9 +60,35 @@ class DataDriftOptions:
             return self.nbinsx.get(feature_name, DEFAULT_NBINSX)
         raise ValueError(f"DataDriftOptions.nbinsx is incorrect type {type(self.nbinsx)}")
 
-    def get_feature_stattest_func(self, feature_name: str, default: PossibleStatTestType) -> PossibleStatTestType:
-        if callable(self.feature_stattest_func) or isinstance(self.feature_stattest_func, (StatTest, str)):
-            return self.feature_stattest_func
-        if isinstance(self.feature_stattest_func, dict):
-            return self.feature_stattest_func.get(feature_name, default)
-        return default
+    def get_feature_stattest_func(
+            self,
+            feature_name: str,
+            feature_type: str,
+            default: PossibleStatTestType) -> PossibleStatTestType:
+        if self.feature_stattest_func is not None and any([self.stattest,
+                                                           self.cat_stattest,
+                                                           self.num_stattest,
+                                                           self.per_feature_stattest]):
+            raise ValueError("Cannot use DataDriftOptions.feature_stattest_func along with any "
+                             "of DataDriftOptions.cat_stattest_func,"
+                             " DataDriftOptions.num_stattest_func,"
+                             " DataDriftOptions.per_feature_stattest_func.")
+        if self.feature_stattest_func is not None:
+            warnings.warn("DataDriftOptions.feature_stattest_func is deprecated use DataDriftOptions.stattest_func"
+                          " or DataDriftOptions.per_feature_stattest_func.")
+            if callable(self.feature_stattest_func) or isinstance(self.feature_stattest_func, (StatTest, str)):
+                return self.feature_stattest_func
+            if isinstance(self.feature_stattest_func, dict):
+                return self.feature_stattest_func.get(feature_name, default)
+            return default
+        func = default if self.stattest is None else self.stattest
+        if feature_type == "cat":
+            type_func = self.cat_stattest
+        elif feature_type == "num":
+            type_func = self.num_stattest
+        else:
+            raise ValueError(f"Unexpected feature type {feature_type}.")
+        func = func if type_func is None else type_func
+        if self.per_feature_stattest is None:
+            return func
+        return self.per_feature_stattest.get(feature_name, func)

--- a/tests/options/test_data_drift.py
+++ b/tests/options/test_data_drift.py
@@ -149,9 +149,9 @@ def test_stattest_function_valid(feature_func, expected):
      _features_st("st2", "st4", "st3", "st5")),
 ])
 def test_stattest_function_valid_v2(global_st, cat_st, num_st, per_feature_st, expected):
-    options = DataDriftOptions(stattest=global_st,
-                               cat_stattest=cat_st,
-                               num_stattest=num_st,
+    options = DataDriftOptions(all_features_stattest=global_st,
+                               cat_features_stattest=cat_st,
+                               num_features_stattest=num_st,
                                per_feature_stattest=per_feature_st)
     for feature, expected_func in expected.items():
         assert options.get_feature_stattest_func(feature, _features[feature], "def_st") == expected_func
@@ -167,9 +167,9 @@ def test_stattest_function_valid_v2(global_st, cat_st, num_st, per_feature_st, e
 ))
 def test_stattest_function_deprecated(feature_st, global_st, cat_st, num_st, per_feature_st):
     options = DataDriftOptions(feature_stattest_func=feature_st,
-                               stattest=global_st,
-                               cat_stattest=cat_st,
-                               num_stattest=num_st,
+                               all_features_stattest=global_st,
+                               cat_features_stattest=cat_st,
+                               num_features_stattest=num_st,
                                per_feature_stattest=per_feature_st)
     with pytest.raises(ValueError):
         options.get_feature_stattest_func("f1", "cat", "def_st")

--- a/tests/options/test_data_drift.py
+++ b/tests/options/test_data_drift.py
@@ -54,15 +54,6 @@ def _another_stattest():
     pass
 
 
-_features = dict([("cat1", "cat"), ("cat2", "cat"), ("num1", "num"), ("num2", "num")])
-
-
-def _features_st(*feature_func):
-    return {t[0]: t[1] for t in
-            zip([f[0] for f in _features.items()], feature_func)
-            if t[1] is not None}
-
-
 @pytest.mark.parametrize("feature_func,expected", [
     (None, {"feature1": "def_st", "feature2": "def_st"}),
     ("st1", {"feature1": "st1", "feature2": "st1"}),
@@ -86,75 +77,71 @@ def test_stattest_function_valid(feature_func, expected):
      None,
      None,
      None,
-     _features_st("def_st", "def_st", "def_st", "def_st")),
+     {"cat1": "def_st", "cat2": "def_st", "num1": "def_st", "num2": "def_st"}),
     ("st1",
      None,
      None,
      None,
-     _features_st("st1", "st1", "st1", "st1")),
+     {"cat1": "st1", "cat2": "st1", "num1": "st1", "num2": "st1"}),
     (None,
      None,
      None,
-     _features_st("st1"),
-     _features_st("st1", "def_st", "def_st", "def_st")),
+     {"cat1": "st1"},
+     {"cat1": "st1", "cat2": "def_st", "num1": "def_st", "num2": "def_st"}),
     (None,
      None,
      None,
-     _features_st(None, _custom_stattest),
-     _features_st("def_st", _custom_stattest, "def_st", "def_st")),
+     {"cat2": _custom_stattest},
+     {"cat1": "def_st", "cat2": _custom_stattest, "num1": "def_st", "num2": "def_st"}),
     (None,
      None,
      None,
-     _features_st(_another_stattest, None, _custom_stattest),
-     _features_st(_another_stattest, "def_st", _custom_stattest, "def_st")),
+     {"cat1": _custom_stattest, "num1": _another_stattest},
+     {"cat1": _custom_stattest, "cat2": "def_st", "num1": _another_stattest, "num2": "def_st"}),
     (None,
      "st1",
      None,
      None,
-     _features_st("st1", "st1", "def_st", "def_st")),
+     {"cat1": "st1", "cat2": "st1", "num1": "def_st", "num2": "def_st"}),
     (None,
      _custom_stattest,
      None,
      None,
-     _features_st(_custom_stattest, _custom_stattest, "def_st", "def_st")),
+     {"cat1": _custom_stattest, "cat2": _custom_stattest, "num1": "def_st", "num2": "def_st"}),
     (None,
      None,
      _custom_stattest,
      None,
-     _features_st("def_st", "def_st", _custom_stattest, _custom_stattest)),
+     {"cat1": "def_st", "cat2": "def_st", "num1": _custom_stattest, "num2": _custom_stattest}),
     ("st1",
      "st2",
      None,
      None,
-     _features_st("st2", "st2", "st1", "st1")),
+     {"cat1": "st2", "cat2": "st2", "num1": "st1", "num2": "st1"}),
     ("st1",
      None,
      "st2",
      None,
-     _features_st("st1", "st1", "st2", "st2")),
-    (_custom_stattest,
-     "st1",
-     None,
-     None,
-     _features_st("st1", "st1", _custom_stattest, _custom_stattest)),
+     {"cat1": "st1", "cat2": "st1", "num1": "st2", "num2": "st2"}),
     ("st1",
      None,
      None,
-     _features_st(None, "st2", None, "st2"),
-     _features_st("st1", "st2", "st1", "st2")),
+     {"cat2": "st2", "num2": "st2"},
+     {"cat1": "st1", "cat2": "st2", "num1": "st1", "num2": "st2"}),
     ("st1",
      "st2",
      "st3",
-     _features_st(None, "st4", None, "st5"),
-     _features_st("st2", "st4", "st3", "st5")),
+     {"cat2": "st4", "num2": "st5"},
+     {"cat1": "st2", "cat2": "st4", "num1": "st3", "num2": "st5"}),
 ])
 def test_stattest_function_valid_v2(global_st, cat_st, num_st, per_feature_st, expected):
+    features_with_types = {"cat1": "cat", "cat2": "cat", "num1": "num", "num2": "num"}
     options = DataDriftOptions(all_features_stattest=global_st,
                                cat_features_stattest=cat_st,
                                num_features_stattest=num_st,
                                per_feature_stattest=per_feature_st)
     for feature, expected_func in expected.items():
-        assert options.get_feature_stattest_func(feature, _features[feature], "def_st") == expected_func
+        assert options.get_feature_stattest_func(feature, features_with_types[feature], "def_st") == expected_func
 
 
 @pytest.mark.parametrize("feature_st,global_st,cat_st,num_st,per_feature_st", (


### PR DESCRIPTION
Replace feature_stattest_func with stattest_func, cat_stattest_func, num_stattest_func, per_feature_stattest_func.
Old parameter left intact with warning on usage and exception if used along with new options.