### PR TITLE
fixed DataQualityMonitorMetrics feature_name return value

### DIFF
--- a/src/evidently/model_monitoring/monitors/data_quality.py
+++ b/src/evidently/model_monitoring/monitors/data_quality.py
@@ -38,7 +38,7 @@ class DataQualityMonitor(ModelMonitor):
                         stat_value,
                         {
                             "dataset": dataset,
-                            "feature": feature_type,
+                            "feature": feature_name,
                             "feature_type": feature_type,
                             "metric": stat_name,
                         },


### PR DESCRIPTION
Fix DataQualityMonitorMetrics yielding wrong value for feature name.

It currently returns feature_type instead of feature_name.