### PR TITLE
added dash to docker compose to README.md and run_example.py script

### DIFF
--- a/examples/integrations/grafana_monitoring_service/README.md
+++ b/examples/integrations/grafana_monitoring_service/README.md
@@ -81,7 +81,7 @@ To stop the process of sending data, cancel the execution of the example script 
 If the Docker containers were not stopped after that, run a command:
 
 ```bash
-docker compose down
+docker-compose down
 ```
 
 ## How to customize the Grafana Dashboard view 

--- a/examples/integrations/grafana_monitoring_service/run_example.py
+++ b/examples/integrations/grafana_monitoring_service/run_example.py
@@ -70,7 +70,7 @@ def download_test_datasets(force: bool):
 
 def run_docker_compose():
     logging.info("Run docker compose")
-    run_script(cmd=["docker", "compose", "up", "-d"], wait=True)
+    run_script(cmd=["docker-compose", "up", "-d"], wait=True)
 
 
 def run_script(cmd: list, wait: bool) -> None:


### PR DESCRIPTION
Submitting a pull request to add a dash to the README.md under the grafana integration examples as well as the `run_example.py`. There is a dash that is needed between `docker` and `compose` for `docker-compose`. Not having the dash for docker compose makes it so that the `run_example.py` errors out before building out the grafana and Prometheus dashboard. 