### PR TITLE
fix success and failed test counting in json summary

### DIFF
--- a/src/evidently/test_suite/test_suite.py
+++ b/src/evidently/test_suite/test_suite.py
@@ -154,15 +154,17 @@ class TestSuite:
             renderer = find_test_renderer(type(test), self._inner_suite.context.renderers)
             test_results.append(renderer.render_json(test))
 
+        total_tests = len(self._inner_suite.context.test_results)
+
         return {
             "version": evidently.__version__,
             "datetime": datetime.now().isoformat(),
             "tests": test_results,
             "summary": {
                 "all_passed": bool(self),
-                "total_tests": len(self._inner_suite.context.test_results),
-                "success_tests": len(self._inner_suite.context.test_results),
-                "failed_tests": len(self._inner_suite.context.test_results),
+                "total_tests": total_tests,
+                "success_tests": counter["SUCCESS"] + counter["WARNING"],
+                "failed_tests": counter["FAIL"],
                 "by_status": counter,
             },
             "columns_info": dataclasses.asdict(self._columns_info),
@@ -182,11 +184,13 @@ class TestSuite:
         test_results = []
         total_tests = len(self._inner_suite.context.test_results)
         by_status = {}
+
         for test, test_result in self._inner_suite.context.test_results.items():
             # renderer = find_test_renderer(type(test.obj), self._inner_suite.context.renderers)
             renderer = find_test_renderer(type(test), self._inner_suite.context.renderers)
             by_status[test_result.status] = by_status.get(test_result.status, 0) + 1
             test_results.append(renderer.render_html(test))
+
         summary_widget = BaseWidgetInfo(
             title="",
             size=2,

--- a/tests/test_suite/test_test_suite.py
+++ b/tests/test_suite/test_test_suite.py
@@ -91,6 +91,8 @@ def test_export_to_json():
         TestColumnValueRegexp(column_name="cat_feature_2", reg_exp=r"[n|y|n//a]"),
         TestConflictTarget(),
         TestConflictPrediction(),
+        TestAllConstantValues(column_name="num_feature_1"),
+        TestAllUniqueValues(column_name="num_feature_1"),
         TestFeatureValueMin(column_name="num_feature_1"),
         TestFeatureValueMax(column_name="num_feature_1"),
         TestFeatureValueMean(column_name="num_feature_1"),
@@ -148,13 +150,13 @@ def test_export_to_json():
     assert summary_result["all_passed"] is False
 
     assert "total_tests" in summary_result
-    assert summary_result["total_tests"] == 34
+    assert summary_result["total_tests"] == 36
 
     assert "success_tests" in summary_result
-    assert summary_result["success_tests"] == 30
+    assert summary_result["success_tests"] == 31
 
     assert "failed_tests" in summary_result
-    assert summary_result["failed_tests"] == 6
+    assert summary_result["failed_tests"] == 5
 
     assert "by_status" in summary_result
-    assert summary_result["by_status"] == {"FAIL": 4, "SUCCESS": 30}
+    assert summary_result["by_status"] == {"FAIL": 5, "SUCCESS": 31}

--- a/tests/test_suite/test_test_suite.py
+++ b/tests/test_suite/test_test_suite.py
@@ -152,5 +152,11 @@ def test_export_to_json():
     assert "total_tests" in summary_result
     assert summary_result["total_tests"] == 36
 
+    assert "success_tests" in summary_result
+    assert summary_result["success_tests"] == 30
+
+    assert "failed_tests" in summary_result
+    assert summary_result["failed_tests"] == 6
+
     assert "by_status" in summary_result
     assert summary_result["by_status"] == {"FAIL": 6, "SUCCESS": 30}


### PR DESCRIPTION
fix for #268 issue

- set `success_tests` as a sum of SUCCESS and WARNING tests
- set `failed_tests ` as all tests in FAIL status