### PR TITLE
fix logic for ApproxValue in lte and gte cases

### DIFF
--- a/src/evidently/tests/utils.py
+++ b/src/evidently/tests/utils.py
@@ -304,13 +304,13 @@ class ApproxValue:
         return self.value + self.tolerance < other
 
     def __le__(self, other):
-        return self.value + self.tolerance <= other
+        return self.value - self.tolerance <= other
 
     def __gt__(self, other):
         return self.value - self.tolerance > other
 
     def __ge__(self, other):
-        return self.value - self.tolerance >= other
+        return self.value + self.tolerance >= other
 
     def as_dict(self) -> dict:
         result = {"value": self.value}

--- a/tests/tests/test_regression_performance_tests.py
+++ b/tests/tests/test_regression_performance_tests.py
@@ -181,7 +181,7 @@ def test_abs_max_error_test_render_json() -> None:
 
     result = json.loads(result_json)["tests"][0]
     assert result == {
-        "description": "The Max Absolute Error is 0.0. The test threshold is lte=0 ± " "1e-12.",
+        "description": "The Max Absolute Error is 0.0. The test threshold is lte=0 ± 1e-12.",
         "group": "regression",
         "name": "Max Absolute Error",
         "parameters": {
@@ -189,7 +189,7 @@ def test_abs_max_error_test_render_json() -> None:
             "abs_error_max_ref": 1.5,
             "condition": {"lte": {"absolute": 1e-12, "relative": 0.1, "value": 0.0}},
         },
-        "status": "FAIL",
+        "status": "SUCCESS",
     }
 
 

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -29,6 +29,7 @@ def test_approx_equals(value, test_value, expected_result):
         (approx(1, absolute=0.2), 1.21, True),
         (approx(1, absolute=0.2), 1.2, False),
         (approx(10, relative=0.1, absolute=0.2), 12.1, True),
+        (approx(1, absolute=0.2), approx(1.4, absolute=0.2), False),
     ),
 )
 def test_approx_lt(value, condition_value, expected_result):
@@ -40,10 +41,16 @@ def test_approx_lt(value, condition_value, expected_result):
     (
         (approx(1, relative=0.5), 1.51, True),
         (approx(1, relative=0.5), 1.5, True),
-        (approx(1, relative=0.5), 1.49, False),
+        (approx(1, relative=0.5), 0.49, False),
         (approx(1, absolute=0.2), 1.21, True),
         (approx(1, absolute=0.2), 1.2, True),
-        (approx(1, absolute=0.2), 1.19, False),
+        (approx(1, absolute=0.2), 0.79, False),
+        # [0.8, 1.2] <= [1.2, 1.6] -> True
+        (approx(1, absolute=0.2), approx(1.4, absolute=0.2), True),
+        # [0.8, 1.2] <= [0.2, 0.8] -> True
+        (approx(1, absolute=0.2), approx(0.5, absolute=0.3), True),
+        # [0.8, 1.2] <= [0.3, 0.7] -> True
+        (approx(1, absolute=0.2), approx(0.5, absolute=0.2), False),
     ),
 )
 def test_approx_lte(value, condition_value, expected_result):
@@ -59,6 +66,8 @@ def test_approx_lte(value, condition_value, expected_result):
         (approx(1, absolute=0.2), 0.79, True),
         (approx(1, absolute=0.2), 0.8, False),
         (approx(1, absolute=0.2), 0.81, False),
+        # [8, 12] > [12, 18] -> False
+        (approx(10, absolute=2), approx(15, absolute=3), False),
     ),
 )
 def test_approx_gt(value, condition_value, expected_result):
@@ -69,11 +78,15 @@ def test_approx_gt(value, condition_value, expected_result):
     "value, condition_value, expected_result",
     (
         (approx(1, relative=0.5), 0.49, True),
-        (approx(1, relative=0.5), 0.5, True),
-        (approx(1, relative=0.5), 0.51, False),
+        (approx(1, relative=0.5), 1.5, True),
+        (approx(1, relative=0.5), 1.51, False),
         (approx(1, absolute=0.2), 0.79, True),
-        (approx(1, absolute=0.2), 0.8, True),
-        (approx(1, absolute=0.2), 0.81, False),
+        (approx(1, absolute=0.2), 1.2, True),
+        (approx(1, absolute=0.2), 1.21, False),
+        # [8, 12] >= [12, 18] -> True
+        (approx(10, absolute=2), approx(15, absolute=3), True),
+        # [8, 12] >= [13, 17] -> False
+        (approx(10, absolute=2), approx(15, absolute=2), False),
     ),
 )
 def test_approx_gte(value, condition_value, expected_result):


### PR DESCRIPTION
There was a bug in lte and gte comparisons in ApproxValue - we did not include equals case in le and ge magic methods.

Fixed the bug and add cases to unit tests, including approx vs. approx comparisons.