### PR TITLE
Adding stat_test to data drift labels and generalizing value

### DIFF
--- a/src/evidently/model_monitoring/monitors/data_drift.py
+++ b/src/evidently/model_monitoring/monitors/data_drift.py
@@ -8,7 +8,7 @@ from evidently.model_monitoring.monitoring import ModelMonitoringMetric
 
 class DataDriftMonitorMetrics:
     _tag = "data_drift"
-    p_value = ModelMonitoringMetric(f"{_tag}:p_value", ["feature", "feature_type"])
+    value = ModelMonitoringMetric(f"{_tag}:value", ["feature", "feature_type", "stat_test"])
     dataset_drift = ModelMonitoringMetric(f"{_tag}:dataset_drift")
     share_drifted_features = ModelMonitoringMetric(f"{_tag}:share_drifted_features")
     n_drifted_features = ModelMonitoringMetric(f"{_tag}:n_drifted_features")
@@ -29,6 +29,6 @@ class DataDriftMonitor(ModelMonitor):
 
         for feature_name in data_drift_results.columns.get_all_features_list(cat_before_num=True):
             feature_metric = data_drift_results.metrics.features[feature_name]
-            yield DataDriftMonitorMetrics.p_value.create(
-                feature_metric.p_value, dict(feature=feature_name, feature_type=feature_metric.feature_type)
+            yield DataDriftMonitorMetrics.value.create(
+                feature_metric.p_value, dict(feature=feature_name, feature_type=feature_metric.feature_type, stat_test=feature_metric.stattest_name)
             )

--- a/tests/model_monitoring/test_monitoring.py
+++ b/tests/model_monitoring/test_monitoring.py
@@ -67,7 +67,7 @@ def test_model_monitoring_with_simple_data():
     assert "num_target_drift:reference_correlations" in result
     assert "data_drift:dataset_drift" in result
     assert "data_drift:n_drifted_features" in result
-    assert "data_drift:p_value" in result
+    assert "data_drift:value" in result
     assert "data_drift:share_drifted_features" in result
     assert "regression_performance:error_normality" in result
     assert "regression_performance:feature_error_bias" in result
@@ -78,6 +78,51 @@ def test_model_monitoring_with_simple_data():
     assert "classification_performance:class_quality" in result
     assert "classification_performance:confusion" in result
     assert "data_quality:quality_stat" in result
+    
+
+def test_data_drift_monitoring_labels_with_simple_data():
+    reference_data = pd.DataFrame(
+        {
+            "target": [1, 2, 3, 4, 5],
+            "prediction": [1, 2, 7, 2, 1],
+            "numerical_feature_1": [0.5, 0.0, 4.8, 2.1, 4.2],
+            "numerical_feature_2": [0, 5, 6, 3, 6],
+            "categorical_feature_1": [1, 1, 0, 1, 0],
+            "categorical_feature_2": [0, 1, 0, 0, 0],
+        }
+    )
+    current_data = pd.DataFrame(
+        {
+            "target": [5, 4, 3, 2, 1],
+            "prediction": [1, 7, 2, 7, 1],
+            "numerical_feature_1": [0.6, 0.1, 45.3, 2.6, 4.2],
+            "numerical_feature_2": [0, 5, 3, 7, 6],
+            "categorical_feature_1": [1, 0, 1, 1, 0],
+            "categorical_feature_2": [0, 1, 0, 1, 1],
+        }
+    )
+    mapping = ColumnMapping(
+        categorical_features=["categorical_feature_1", "categorical_feature_2"],
+        numerical_features=["numerical_feature_1", "numerical_feature_2"],
+    )
+    evidently_monitoring = ModelMonitoring(
+        monitors=[
+            DataDriftMonitor(),
+        ],
+        options=None,
+    )
+    evidently_monitoring.execute(reference_data=reference_data, current_data=current_data, column_mapping=mapping)
+    result = collect_metrics_results(evidently_monitoring.metrics())
+
+    assert "data_drift:dataset_drift" in result
+    assert "data_drift:n_drifted_features" in result
+    assert "data_drift:value" in result
+
+    data_drift_value = result["data_drift:value"]
+    for e in data_drift_value:
+        assert 'stat_test' in e['labels']
+        assert 'feature' in e['labels']
+        assert 'feature_type' in e['labels']
 
 
 def test_metric_creation_with_incorrect_labels():


### PR DESCRIPTION
Details for the PR can be found in issue [306](https://github.com/evidentlyai/evidently/issues/306).

To summarize, currently the `metrics` method of the `DataDriftMonitor` class doesn't surface the name of the statistical test used to analyze a feature. Moreover, using `p_value` as a hardcoded label for all statistical tests is not ideal since not all tests output a probability (Wasserstein distance  for example). 

An additional unit test is included in the PR to ensure that the `stat_test` label is always present in `DataDriftMonitor` results.