### PR TITLE
fix drop nans in stat tests

### DIFF
--- a/src/evidently/calculations/stattests/chisquare_stattest.py
+++ b/src/evidently/calculations/stattests/chisquare_stattest.py
@@ -2,25 +2,21 @@
 # coding: utf-8
 from typing import Tuple
 
-import numpy as np
 import pandas as pd
 from scipy.stats import chisquare
 
 from evidently.calculations.stattests.registry import StatTest
 from evidently.calculations.stattests.registry import register_stattest
+from evidently.calculations.stattests.utils import get_unique_values_list_from_series
 
 
 def _chi_stat_test(
     reference_data: pd.Series, current_data: pd.Series, feature_type: str, threshold: float
 ) -> Tuple[float, bool]:
-    #  TODO: simplify ignoring NaN values here, in z_stat_test and data_drift_analyzer
-    keys = list((set(reference_data) | set(current_data)) - {np.nan})
-
+    keys = get_unique_values_list_from_series(current_data=current_data, reference_data=reference_data)
     ref_feature_dict = {**dict.fromkeys(keys, 0), **dict(reference_data.value_counts())}
     current_feature_dict = {**dict.fromkeys(keys, 0), **dict(current_data.value_counts())}
-
     k_norm = current_data.shape[0] / reference_data.shape[0]
-
     f_exp = [ref_feature_dict[key] * k_norm for key in keys]
     f_obs = [current_feature_dict[key] for key in keys]
     p_value = chisquare(f_obs, f_exp)[1]

--- a/src/evidently/calculations/stattests/chisquare_stattest.py
+++ b/src/evidently/calculations/stattests/chisquare_stattest.py
@@ -7,13 +7,13 @@ from scipy.stats import chisquare
 
 from evidently.calculations.stattests.registry import StatTest
 from evidently.calculations.stattests.registry import register_stattest
-from evidently.calculations.stattests.utils import get_unique_values_list_from_series
+from evidently.calculations.stattests.utils import get_unique_not_nan_values_list_from_series
 
 
 def _chi_stat_test(
     reference_data: pd.Series, current_data: pd.Series, feature_type: str, threshold: float
 ) -> Tuple[float, bool]:
-    keys = get_unique_values_list_from_series(current_data=current_data, reference_data=reference_data)
+    keys = get_unique_not_nan_values_list_from_series(current_data=current_data, reference_data=reference_data)
     ref_feature_dict = {**dict.fromkeys(keys, 0), **dict(reference_data.value_counts())}
     current_feature_dict = {**dict.fromkeys(keys, 0), **dict(current_data.value_counts())}
     k_norm = current_data.shape[0] / reference_data.shape[0]

--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -2,33 +2,38 @@ import numpy as np
 import pandas as pd
 
 
-def get_binned_data(reference: pd.Series, current: pd.Series, feature_type: str, n: int, feel_zeroes: bool = True):
+def get_unique_values_list_from_series(current_data: pd.Series, reference_data: pd.Series) -> list:
+    """Get unique values from current and reference series, drop NaNs"""
+    return list(set(reference_data.dropna().unique()) | set(current_data.dropna().unique()))
+
+
+def get_binned_data(
+    reference_data: pd.Series, current_data: pd.Series, feature_type: str, n: int, feel_zeroes: bool = True
+):
     """Split variable into n buckets based on reference quantiles
     Args:
-        reference: reference data
-        current: current data
+        reference_data: reference data
+        current_data: current data
         feature_type: feature type
         n: number of quantiles
     Returns:
         reference_percents: % of records in each bucket for reference
         current_percents: % of records in each bucket for reference
     """
-    n_vals = reference.nunique()
+    n_vals = reference_data.nunique()
+
     if feature_type == "num" and n_vals > 20:
-
-        bins = np.histogram_bin_edges(list(reference) + list(current), bins="sturges")
-
-        reference_percents = np.histogram(reference, bins)[0] / len(reference)
-        current_percents = np.histogram(current, bins)[0] / len(current)
+        bins = np.histogram_bin_edges(list(reference_data) + list(current_data), bins="sturges")
+        reference_percents = np.histogram(reference_data, bins)[0] / len(reference_data)
+        current_percents = np.histogram(current_data, bins)[0] / len(current_data)
 
     else:
-        keys = list((set(reference.unique()) | set(current.unique())) - {np.nan})
+        keys = get_unique_values_list_from_series(current_data=current_data, reference_data=reference_data)
+        ref_feature_dict = {**dict.fromkeys(keys, 0), **dict(reference_data.value_counts())}
+        current_feature_dict = {**dict.fromkeys(keys, 0), **dict(current_data.value_counts())}
+        reference_percents = np.array([ref_feature_dict[key] / len(reference_data) for key in keys])
+        current_percents = np.array([current_feature_dict[key] / len(current_data) for key in keys])
 
-        ref_feature_dict = {**dict.fromkeys(keys, 0), **dict(reference.value_counts())}
-        current_feature_dict = {**dict.fromkeys(keys, 0), **dict(current.value_counts())}
-
-        reference_percents = np.array([ref_feature_dict[key] / len(reference) for key in keys])
-        current_percents = np.array([current_feature_dict[key] / len(current) for key in keys])
     if feel_zeroes:
         np.place(reference_percents, reference_percents == 0, 0.0001)
         np.place(current_percents, current_percents == 0, 0.0001)

--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 
-def get_unique_values_list_from_series(current_data: pd.Series, reference_data: pd.Series) -> list:
+def get_unique_not_nan_values_list_from_series(current_data: pd.Series, reference_data: pd.Series) -> list:
     """Get unique values from current and reference series, drop NaNs"""
     return list(set(reference_data.dropna().unique()) | set(current_data.dropna().unique()))
 
@@ -28,7 +28,7 @@ def get_binned_data(
         current_percents = np.histogram(current_data, bins)[0] / len(current_data)
 
     else:
-        keys = get_unique_values_list_from_series(current_data=current_data, reference_data=reference_data)
+        keys = get_unique_not_nan_values_list_from_series(current_data=current_data, reference_data=reference_data)
         ref_feature_dict = {**dict.fromkeys(keys, 0), **dict(reference_data.value_counts())}
         current_feature_dict = {**dict.fromkeys(keys, 0), **dict(current_data.value_counts())}
         reference_percents = np.array([ref_feature_dict[key] / len(reference_data) for key in keys])

--- a/src/evidently/calculations/stattests/z_stattest.py
+++ b/src/evidently/calculations/stattests/z_stattest.py
@@ -39,7 +39,6 @@ def proportions_diff_z_test(z_stat, alternative="two-sided"):
 def _z_stat_test(
     reference_data: pd.Series, current_data: pd.Series, feature_type: str, threshold: float
 ) -> Tuple[float, bool]:
-    #  TODO: simplify ignoring NaN values here, in chi_stat_test and data_drift_analyzer
     if (
         reference_data.nunique() == 1
         and current_data.nunique() == 1

--- a/src/evidently/calculations/stattests/z_stattest.py
+++ b/src/evidently/calculations/stattests/z_stattest.py
@@ -46,7 +46,9 @@ def _z_stat_test(
     ):
         p_value = 1
     else:
-        keys = sorted(get_unique_not_nan_values_list_from_series(current_data=current_data, reference_data=reference_data))
+        keys = sorted(
+            get_unique_not_nan_values_list_from_series(current_data=current_data, reference_data=reference_data)
+        )
         p_value = proportions_diff_z_test(
             proportions_diff_z_stat_ind(
                 reference_data.apply(lambda x, key=keys[0]: 0 if x == key else 1),

--- a/src/evidently/calculations/stattests/z_stattest.py
+++ b/src/evidently/calculations/stattests/z_stattest.py
@@ -8,7 +8,7 @@ from scipy.stats import norm
 
 from evidently.calculations.stattests.registry import StatTest
 from evidently.calculations.stattests.registry import register_stattest
-from evidently.calculations.stattests.utils import get_unique_values_list_from_series
+from evidently.calculations.stattests.utils import get_unique_not_nan_values_list_from_series
 
 
 def proportions_diff_z_stat_ind(ref: pd.DataFrame, curr: pd.DataFrame):
@@ -46,7 +46,7 @@ def _z_stat_test(
     ):
         p_value = 1
     else:
-        keys = sorted(get_unique_values_list_from_series(current_data=current_data, reference_data=reference_data))
+        keys = sorted(get_unique_not_nan_values_list_from_series(current_data=current_data, reference_data=reference_data))
         p_value = proportions_diff_z_test(
             proportions_diff_z_stat_ind(
                 reference_data.apply(lambda x, key=keys[0]: 0 if x == key else 1),

--- a/src/evidently/calculations/stattests/z_stattest.py
+++ b/src/evidently/calculations/stattests/z_stattest.py
@@ -8,6 +8,7 @@ from scipy.stats import norm
 
 from evidently.calculations.stattests.registry import StatTest
 from evidently.calculations.stattests.registry import register_stattest
+from evidently.calculations.stattests.utils import get_unique_values_list_from_series
 
 
 def proportions_diff_z_stat_ind(ref: pd.DataFrame, curr: pd.DataFrame):
@@ -46,12 +47,11 @@ def _z_stat_test(
     ):
         p_value = 1
     else:
-        keys = set(list(reference_data.unique()) + list(current_data.unique())) - {np.nan}
-        ordered_keys = sorted(list(keys))
+        keys = sorted(get_unique_values_list_from_series(current_data=current_data, reference_data=reference_data))
         p_value = proportions_diff_z_test(
             proportions_diff_z_stat_ind(
-                reference_data.apply(lambda x, key=ordered_keys[0]: 0 if x == key else 1),
-                current_data.apply(lambda x, key=ordered_keys[0]: 0 if x == key else 1),
+                reference_data.apply(lambda x, key=keys[0]: 0 if x == key else 1),
+                current_data.apply(lambda x, key=keys[0]: 0 if x == key else 1),
             )
         )
     return p_value, p_value < threshold

--- a/tests/calculations/stattests/test_utils.py
+++ b/tests/calculations/stattests/test_utils.py
@@ -13,9 +13,9 @@ from evidently.calculations.stattests.utils import get_unique_not_nan_values_lis
         (pd.Series(["a", "b", "a", "c"]), pd.Series(["d", "e"]), ["b", "d", "e", "c", "a"]),
         (pd.Series(["a", None, "a", np.NAN]), pd.Series([4, 5]), [4, 5, "a"]),
         (pd.Series([pd.NA, pd.NaT, np.NAN]), pd.Series([pd.NA, pd.NaT, np.NAN]), []),
-    )
+    ),
 )
 def test_get_unique_not_nan_values_list_from_series(current_data: pd.Series, reference_data: pd.Series, expected_list):
-    assert set(get_unique_not_nan_values_list_from_series(
-        current_data=current_data, reference_data=reference_data
-    )) == set(expected_list)
+    assert set(
+        get_unique_not_nan_values_list_from_series(current_data=current_data, reference_data=reference_data)
+    ) == set(expected_list)

--- a/tests/calculations/stattests/test_utils.py
+++ b/tests/calculations/stattests/test_utils.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from evidently.calculations.stattests.utils import get_unique_not_nan_values_list_from_series
+
+
+@pytest.mark.parametrize(
+    "current_data, reference_data, expected_list",
+    (
+        (pd.Series([1, 2, 3, 3, 5]), pd.Series([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]),
+        (pd.Series([1, 2, 3, 4]), pd.Series([5, 5]), [1, 2, 3, 4, 5]),
+        (pd.Series(["a", "b", "a", "c"]), pd.Series(["d", "e"]), ["b", "d", "e", "c", "a"]),
+        (pd.Series(["a", None, "a", np.NAN]), pd.Series([4, 5]), [4, 5, "a"]),
+        (pd.Series([pd.NA, pd.NaT, np.NAN]), pd.Series([pd.NA, pd.NaT, np.NAN]), []),
+    )
+)
+def test_get_unique_not_nan_values_list_from_series(current_data: pd.Series, reference_data: pd.Series, expected_list):
+    assert set(get_unique_not_nan_values_list_from_series(
+        current_data=current_data, reference_data=reference_data
+    )) == set(expected_list)

--- a/tests/stattests/test_stattests.py
+++ b/tests/stattests/test_stattests.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from pytest import approx
 
 from evidently.calculations.stattests import z_stat_test
@@ -19,10 +20,25 @@ def test_chi_stat_test_cat_feature() -> None:
     assert chi_stat_test.func(reference, current, "cat", 0.5) == (approx(1.0, abs=1e-5), False)
 
 
-def test_z_stat_test_cat_feature() -> None:
-    reference = pd.Series(["a", "b"]).repeat([10, 10])
-    current = pd.Series(["a", "b"]).repeat([10, 10])
-    assert z_stat_test.func(reference, current, "cat", 0.5) == (approx(1.0, abs=1e-5), False)
+@pytest.mark.parametrize(
+    "reference, current, expected_score, expected_condition_result",
+    (
+        (
+            pd.Series(["a", "b"] * 10),
+            pd.Series(["a", "b"] * 10),
+            approx(1.0, abs=1e-5),
+            False,
+        ),
+        (
+            pd.Series(["a", np.nan] * 10),
+            pd.Series(["a", "b"] * 10),
+            approx(1.0, abs=1e-5),
+            False,
+        ),
+    ),
+)
+def test_z_stat_test_cat_feature(reference, current, expected_score, expected_condition_result: bool) -> None:
+    assert z_stat_test.func(reference, current, "cat", 0.5) == (expected_score, expected_condition_result)
 
 
 def test_cat_feature_with_nans() -> None:


### PR DESCRIPTION
- fix ignoring NaNs in stat tests - move it to a separate method `get_unique_values_list_from_series` and use  `dropna()` instead of `- {np.nan}`
- align naming in `get_binned_data` method - use the same as in all stat tests
- add tests with nans for `z_stat_test`