### PR TITLE
Add anderson darling test for drift detection

### DIFF
--- a/src/evidently/calculations/stattests/anderson_darling_stattest.py
+++ b/src/evidently/calculations/stattests/anderson_darling_stattest.py
@@ -1,0 +1,39 @@
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.stats import anderson_ksamp
+
+from evidently.calculations.stattests.registry import StatTest
+from evidently.calculations.stattests.registry import register_stattest
+
+
+def _anderson_darling(
+    reference_data: pd.Series,
+    current_data: pd.Series,
+    feature_type: str,
+    threshold: float,
+) -> Tuple[float, bool]:
+    """Run the  Anderson-Darling test of two samples.
+    Args:
+        reference_data: reference data
+        current_data: current data
+        feature_type: feature type
+        threshold: level of significance
+    Returns:
+        p_value: p-value
+        test_result: whether the drift is detected
+    """
+    p_value = anderson_ksamp(np.array([reference_data, current_data]))[2]
+    return p_value, p_value < threshold
+
+
+anderson_darling_test = StatTest(
+    name="anderson",
+    display_name="Anderson-Darling",
+    func=_anderson_darling,
+    allowed_feature_types=["num"],
+    default_threshold=0.1,
+)
+
+register_stattest(anderson_darling_test)

--- a/tests/stattests/test_stattests.py
+++ b/tests/stattests/test_stattests.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pytest import approx
 
 from evidently.calculations.stattests import z_stat_test
+from evidently.calculations.stattests.anderson_darling_stattest import anderson_darling_test
 from evidently.calculations.stattests.chisquare_stattest import chi_stat_test
 
 
@@ -36,3 +37,9 @@ def test_freq_obs_not_eq_freq_exp() -> None:
     reference = pd.Series([1, 2, 3, 4, 5, 6]).repeat([x * 2 for x in [16, 18, 16, 14, 12, 12]])
     current = pd.Series([1, 2, 3, 4, 5, 6]).repeat([16, 16, 16, 16, 16, 8])
     assert chi_stat_test.func(reference, current, "cat", 0.5) == (approx(0.67309, abs=1e-5), False)
+
+
+def test_anderson_darling() -> None:
+    reference = pd.Series([38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0])
+    current = pd.Series([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
+    assert anderson_darling_test.func(reference, current, "num", 0.001) == (approx(0.0635, abs=1e-3), False)


### PR DESCRIPTION
**Issue**:  
#344 (Anderson–Darling stat test for Drift Analysis)

**What does this implement/fix?**
Adds anderson darling test

Did look into [`scipy.stats.anderson`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anderson.html)
but went ahead with [`scipy.stats.anderson_ksamp`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.anderson_ksamp.html)

@emeli-dral 
Please let me know if any improvements or changes are needed.
Thanks