### PR TITLE
fix warning about duplicated columns in data drift

### DIFF
--- a/examples/how_to_questions/metrics/data_drift_metrics.ipynb
+++ b/examples/how_to_questions/metrics/data_drift_metrics.ipynb
@@ -180,6 +180,27 @@
    "id": "98d6ad30",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "from evidently.test_preset import NoTargetPerformance\n",
+    "from evidently.test_suite import TestSuite\n",
+    "\n",
+    "\n",
+    "data_quality_suite = TestSuite(\n",
+    "        tests=[\n",
+    "            NoTargetPerformance(most_important_features=[\"education-num\", \"hours-per-week\"]),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "data_quality_suite.run(current_data=current_data, reference_data=reference_data)\n",
+    "data_quality_suite"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0903e55",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/src/evidently/calculations/data_drift.py
+++ b/src/evidently/calculations/data_drift.py
@@ -119,8 +119,10 @@ def get_one_column_drift(
             raise ValueError(f"Column {column_name} should only contain numerical values.")
 
         numeric_columns = dataset_columns.num_feature_names
+
         if column_name not in numeric_columns:
-            numeric_columns.append(column_name)
+            # for target and prediction cases add the column_name in the numeric columns list
+            numeric_columns = numeric_columns + [column_name]
 
         result.current_correlations = current_data[numeric_columns].corr()[column_name].to_dict()
         result.reference_correlations = reference_data[numeric_columns].corr()[column_name].to_dict()

--- a/src/evidently/calculations/data_drift.py
+++ b/src/evidently/calculations/data_drift.py
@@ -119,8 +119,11 @@ def get_one_column_drift(
             raise ValueError(f"Column {column_name} should only contain numerical values.")
 
         numeric_columns = dataset_columns.num_feature_names
-        result.current_correlations = current_data[numeric_columns + [column_name]].corr()[column_name].to_dict()
-        result.reference_correlations = reference_data[numeric_columns + [column_name]].corr()[column_name].to_dict()
+        if column_name not in numeric_columns:
+            numeric_columns.append(column_name)
+
+        result.current_correlations = current_data[numeric_columns].corr()[column_name].to_dict()
+        result.reference_correlations = reference_data[numeric_columns].corr()[column_name].to_dict()
         current_nbinsx = options.get_nbinsx(column_name)
         result.current_small_distribution = [
             t.tolist()


### PR DESCRIPTION
ensure that in a list for correlation calculation in data drift not contain duplicated target column