### PR TITLE
fix for issue #334 feel zeroes of stattests utils

### DIFF
--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -35,7 +35,7 @@ def get_binned_data(
         current_percents = np.array([current_feature_dict[key] / len(current_data) for key in keys])
 
     if feel_zeroes:
-        np.place(reference_percents, reference_percents == 0, 0.0001)
-        np.place(current_percents, current_percents == 0, 0.0001)
+        np.place(reference_percents, reference_percents == 0, min(reference_percents[reference_percents != 0]) / 10**6 if min(reference_percents[reference_percents != 0]) <= 0.0001 else 0.0001)
+        np.place(current_percents, current_percents == 0, min(current_percents[current_percents != 0]) / 10**6 if min(current_percents[current_percents != 0]) <= 0.0001 else 0.0001)
 
     return reference_percents, current_percents

--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -35,7 +35,19 @@ def get_binned_data(
         current_percents = np.array([current_feature_dict[key] / len(current_data) for key in keys])
 
     if feel_zeroes:
-        np.place(reference_percents, reference_percents == 0, min(reference_percents[reference_percents != 0]) / 10**6 if min(reference_percents[reference_percents != 0]) <= 0.0001 else 0.0001)
-        np.place(current_percents, current_percents == 0, min(current_percents[current_percents != 0]) / 10**6 if min(current_percents[current_percents != 0]) <= 0.0001 else 0.0001)
+        np.place(
+            reference_percents,
+            reference_percents == 0,
+            min(reference_percents[reference_percents != 0]) / 10**6
+            if min(reference_percents[reference_percents != 0]) <= 0.0001
+            else 0.0001,
+        )
+        np.place(
+            current_percents,
+            current_percents == 0,
+            min(current_percents[current_percents != 0]) / 10**6
+            if min(current_percents[current_percents != 0]) <= 0.0001
+            else 0.0001,
+        )
 
     return reference_percents, current_percents


### PR DESCRIPTION
#334 

Temporarily added a fix for the issue mentioned by @chi2liu.

Now if the minimum percent in the data is less than or equal to 0.0001, the zeroes will be converted to minimum /10^6.

10^6 was chosen to have the same effect as 0.0001 has when the minimum is not less than or equal to 0.0001.

This needs more discussion because if you increase the 10^6, the drift metrics will also increase. 
In my opinion, they should be as close to zero as we can (compared to the other values).

check this notebook for an example that you can run: https://github.com/AntonisCSt/evidently/blob/example-utils/src/utils_feel_zeroes_issue_fix.ipynb