### PR TITLE
Add CVM in examples

### DIFF
--- a/examples/how_to_questions/how_to_specify_stattest_for_a_testsuite.ipynb
+++ b/examples/how_to_questions/how_to_specify_stattest_for_a_testsuite.ipynb
@@ -124,6 +124,7 @@
     "* 'psi' \n",
     "* 'wasserstein'\n",
     "* 'anderson'\n",
+    "* 'cramer_von_mises'\n",
     "\n",
     "You can implement a custom drift test and use it in DataDriftOptions. Just define a function that takes two pd.Series (reference and current data) and returns a number (e.g. p_value or distance)\n",
     "\n",
@@ -229,8 +230,7 @@
    },
    "outputs": [],
    "source": [
-    "per_feature_stattest = {x: 'wasserstein' for x in ['age', 'education-num', \n",
-    "                                                   'capital-gain', 'capital-loss']}\n",
+    "per_feature_stattest = {x: 'wasserstein' for x in ['age', 'education-num']}\n",
     "for column in ['sex', 'class']:\n",
     "    per_feature_stattest[column] = 'z'\n",
     "for column in ['workclass', 'education', 'marital-status']:\n",
@@ -238,7 +238,9 @@
     "for column in ['occupation', 'relationship', 'race',  'native-country']:\n",
     "    per_feature_stattest[column] = 'jensenshannon'\n",
     "for column in ['fnlwgt','hours-per-week']:\n",
-    "    per_feature_stattest[column] = 'anderson'"
+    "    per_feature_stattest[column] = 'anderson'\n",
+    "for column in ['capital-gain','capital-loss']:\n",
+    "    per_feature_stattest[column] = 'cramer_von_mises'"
    ]
   },
   {

--- a/src/evidently/calculations/stattests/__init__.py
+++ b/src/evidently/calculations/stattests/__init__.py
@@ -3,6 +3,7 @@
 from .anderson_darling_stattest import anderson_darling_test
 from .chisquare_stattest import chi_stat_test
 from .jensenshannon import jensenshannon_stat_test
+from .cramer_von_mises_stattest import cramer_von_mises
 from .kl_div import kl_div_stat_test
 from .ks_stattest import ks_stat_test
 from .psi import psi_stat_test

--- a/src/evidently/calculations/stattests/__init__.py
+++ b/src/evidently/calculations/stattests/__init__.py
@@ -2,8 +2,8 @@
 # coding: utf-8
 from .anderson_darling_stattest import anderson_darling_test
 from .chisquare_stattest import chi_stat_test
-from .jensenshannon import jensenshannon_stat_test
 from .cramer_von_mises_stattest import cramer_von_mises
+from .jensenshannon import jensenshannon_stat_test
 from .kl_div import kl_div_stat_test
 from .ks_stattest import ks_stat_test
 from .psi import psi_stat_test


### PR DESCRIPTION
**Issue: #343** 

**what does this implement/fix?**
adds `cramer-von-mises` in examples notebook