### PR TITLE
Energy distance num drift test

### DIFF
--- a/docs/book/customization/options-for-statistical-tests.md
+++ b/docs/book/customization/options-for-statistical-tests.md
@@ -180,3 +180,7 @@ example_stat_test = StatTest(
   - only for numerical features
   - returns `p_value`
   - drift detected when `p_value < threshold`
+- `ed` - Energy distance
+  - only for numerical features
+  - returns `distance`
+  - drift detected when `distance >= threshold`

--- a/src/evidently/calculations/stattests/__init__.py
+++ b/src/evidently/calculations/stattests/__init__.py
@@ -3,6 +3,7 @@
 from .anderson_darling_stattest import anderson_darling_test
 from .chisquare_stattest import chi_stat_test
 from .cramer_von_mises_stattest import cramer_von_mises
+from .energy_distance import energy_dist_test
 from .g_stattest import g_test
 from .jensenshannon import jensenshannon_stat_test
 from .kl_div import kl_div_stat_test

--- a/src/evidently/calculations/stattests/energy_distance.py
+++ b/src/evidently/calculations/stattests/energy_distance.py
@@ -1,0 +1,30 @@
+from typing import Tuple
+
+import pandas as pd
+from scipy.stats import energy_distance
+
+from evidently.calculations.stattests.registry import StatTest
+from evidently.calculations.stattests.registry import register_stattest
+
+
+def _energy_dist(
+    reference_data: pd.Series, current_data: pd.Series, feature_type: str, threshold: float
+) -> Tuple[float, bool]:
+    """Run the energy_distance test of two samples.
+    Args:
+        reference_data: reference data
+        current_data: current data
+        threshold: all values above this threshold propose a data drift
+    Returns:
+        distance: energy distance
+        test_result: whether the drift is detected
+    """
+    distance = energy_distance(reference_data, current_data)
+    return distance, distance > threshold
+
+
+energy_dist_test = StatTest(
+    name="ed", display_name="Energy-distance", func=_energy_dist, allowed_feature_types=["num"], default_threshold=0.1
+)
+
+register_stattest(energy_dist_test)

--- a/tests/stattests/test_stattests.py
+++ b/tests/stattests/test_stattests.py
@@ -7,6 +7,7 @@ from evidently.calculations.stattests import z_stat_test
 from evidently.calculations.stattests.anderson_darling_stattest import anderson_darling_test
 from evidently.calculations.stattests.chisquare_stattest import chi_stat_test
 from evidently.calculations.stattests.cramer_von_mises_stattest import cramer_von_mises
+from evidently.calculations.stattests.energy_distance import energy_dist_test
 from evidently.calculations.stattests.g_stattest import g_test
 from evidently.calculations.stattests.hellinger_distance import hellinger_stat_test
 from evidently.calculations.stattests.mann_whitney_urank_stattest import mann_whitney_u_stat_test
@@ -130,3 +131,10 @@ def test_mann_whitney() -> None:
     reference = pd.Series([1, 2, 3, 4, 5, 6]).repeat([16, 18, 16, 14, 12, 12])
     current = pd.Series([1, 2, 3, 4, 5, 6]).repeat([16, 16, 16, 16, 16, 8])
     assert mann_whitney_u_stat_test.func(reference, current, "num", 0.05) == (approx(0.481, abs=1e-2), False)
+
+
+def test_energy_distance() -> None:
+    reference = pd.Series([38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0, np.nan])
+    current = pd.Series([38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0, np.nan])
+    assert energy_dist_test.func(reference, current, "num", 0.1) == (approx(0, abs=1e-5), False)
+    assert energy_dist_test.func(reference, current + 5, "num", 0.1) == (approx(1.9, abs=1e-1), True)


### PR DESCRIPTION
#378 

Added Energy distance proposed by issue 378:

This one was very interesting! It was influenced by **_Newton's [gravitational potential](https://www.sciencedirect.com/topics/mathematics/gravitational-potential) energy, and there is an elegant relation to the notion of potential energy between statistical observations._**

While there were a lot of theoretical sources, apart from scipy's library (from which I borrowed the methodology), I could not find many practical ones.

I tested on multiple distributions (drifted cases and non-drifted) and found that the threshold of 0.1 is satisfying.

If you have any other useful resources please let me know :)

Enjoy for now!

sources: [wikipedia Energy distance](https://en.wikipedia.org/wiki/Energy_distance)
[Scipy library](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.energy_distance.html#id1)
[Energy statistics: A class of statistics based on distances](https://doi.org/10.1016/j.jspi.2013.03.018)