### PR TITLE
Fix widget size in ColumnValuePlot and titles in DatasetDriftMetric

### DIFF
--- a/examples/how_to_questions/metrics/data_drift_metrics.ipynb
+++ b/examples/how_to_questions/metrics/data_drift_metrics.ipynb
@@ -175,6 +175,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6443dedd",
+   "metadata": {},
+   "source": [
+    "## One Column Value Plot Metric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95a0e6e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evidently.metrics import ColumnValuePlot\n",
+    "\n",
+    "report = Report(metrics=[ColumnValuePlot(column_name=\"age\")])\n",
+    "report.run(current_data=current_data, reference_data=reference_data)\n",
+    "report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b307cbf5",
+   "metadata": {},
+   "source": [
+    "## Data Drift tests"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "98d6ad30",
@@ -198,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0903e55",
+   "id": "66c1f185",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/evidently/metrics/data_drift/column_value_plot.py
+++ b/src/evidently/metrics/data_drift/column_value_plot.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -8,22 +7,15 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype
 from plotly import graph_objs as go
 
-from evidently.calculations.data_drift import get_one_column_drift
 from evidently.metrics.base_metric import InputData
 from evidently.metrics.base_metric import Metric
 from evidently.model.widget import BaseWidgetInfo
-from evidently.options import DataDriftOptions
 from evidently.options.color_scheme import ColorOptions
 from evidently.renderers.base_renderer import MetricRenderer
 from evidently.renderers.base_renderer import default_renderer
-from evidently.renderers.html_widgets import CounterData
-from evidently.renderers.html_widgets import GraphData
 from evidently.renderers.html_widgets import WidgetSize
 from evidently.renderers.html_widgets import plotly_figure
-from evidently.renderers.render_utils import get_distribution_plot_figure
 from evidently.utils.data_operations import process_columns
-from evidently.utils.types import Numeric
-from evidently.utils.visualizations import Distribution
 
 
 @dataclasses.dataclass
@@ -173,4 +165,4 @@ class ColumnValuePlotRenderer(MetricRenderer):
                 ),
             ],
         )
-        return [plotly_figure(title=f"{column_name} Values", figure=fig, size=WidgetSize.HALF)]
+        return [plotly_figure(title=f"Column '{column_name}' Values", figure=fig, size=WidgetSize.FULL)]

--- a/src/evidently/metrics/data_drift/dataset_drift_metric.py
+++ b/src/evidently/metrics/data_drift/dataset_drift_metric.py
@@ -92,8 +92,8 @@ class DataDriftMetricsRenderer(MetricRenderer):
             counter(
                 counters=[
                     CounterData(
-                        f"Dataset Drift is {drift_detected}",
                         f"Dataset drift detection threshold is {result.threshold}",
+                        f"Dataset Drift is {drift_detected}",
                     )
                 ],
                 title="",


### PR DESCRIPTION
- set widget size in `ColumnValuePlot` to `full`
- update title in `ColumnValuePlot`
- update title in `DatasetDriftMetric`
- add `ColumnValuePlot` to data drift metrics example notebook