### PR TITLE
Remove version restriction for PyYAML library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup_args = dict(
         "nltk>=3.6.7",
         "scipy>=1.5.4",
         "requests>=2.19.0",
-        "PyYAML~=5.1",
+        "PyYAML>=5.1",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Fix #526 