### PR TITLE
MobAd BigData Beeline Kazakhstan: add lift table and lift curve metrics

### DIFF
--- a/src/evidently/calculations/classification_performance.py
+++ b/src/evidently/calculations/classification_performance.py
@@ -262,11 +262,27 @@ def calculate_pr_table(binded):
         result.append([top, int(count), prob, int(tp), int(fp), precision, recall])
     return result
 
-def calculate_lift_table(binded):
+
+def calculate_lift_table(binded: List[tuple]) -> List[List]:
+    """
+    Calculate all needed table data for lift metric analysis and visualization
+
+    Parameters
+    ----------
+    binded: List[tuple]
+        Zipped together binarized facts(0 or 1) and probabilistic prediction
+
+    Return values
+    -------------
+    result: List[List]
+        Data for lift metric analysis and visualization
+    """
     result = []
     binded.sort(key=lambda item: item[1], reverse=True)
     data_size = len(binded)
     target_class_size = sum([x[0] for x in binded])
+    # we don't use declared STEP_SIZE due to specifics
+    # of lift metric calculation and visualization
     offset = max(round(data_size * 0.01), 1)
 
     for step in np.arange(offset, data_size + offset, offset):
@@ -277,7 +293,7 @@ def calculate_lift_table(binded):
         fp = count - tp
         precision = round(100.0 * tp / count, 1)
         recall = round(100.0 * tp / target_class_size, 1)
-        f1_score = round(2/(1/precision+1/recall), 1)
+        f1_score = round(2 / (1 / precision + 1 / recall), 1)
         lift = round(recall / top, 2)
         if count <= target_class_size:
             max_lift = round(100.0 * count / target_class_size / top, 2)

--- a/src/evidently/calculations/classification_performance.py
+++ b/src/evidently/calculations/classification_performance.py
@@ -266,12 +266,10 @@ def calculate_pr_table(binded):
 def calculate_lift_table(binded: List[tuple]) -> List[List]:
     """
     Calculate all needed table data for lift metric analysis and visualization
-
     Parameters
     ----------
     binded: List[tuple]
         Zipped together binarized facts(0 or 1) and probabilistic prediction
-
     Return values
     -------------
     result: List[List]
@@ -283,9 +281,9 @@ def calculate_lift_table(binded: List[tuple]) -> List[List]:
     target_class_size = sum([x[0] for x in binded])
     # we don't use declared STEP_SIZE due to specifics
     # of lift metric calculation and visualization
-    offset = max(round(data_size * 0.01), 1)
+    offset = int(max(np.floor(data_size * 0.01), 1))
 
-    for step in np.arange(offset, data_size + offset, offset):
+    for step in np.arange(offset, data_size + 1, offset):
         count = min(step, data_size)
         prob = round(binded[min(step, data_size - 1)][1], 2)
         top = round(100.0 * min(step, data_size) / data_size)

--- a/src/evidently/calculations/classification_performance.py
+++ b/src/evidently/calculations/classification_performance.py
@@ -263,18 +263,7 @@ def calculate_pr_table(binded):
     return result
 
 
-def calculate_lift_table(binded: List[tuple]) -> List[List]:
-    """
-    Calculate all needed table data for lift metric analysis and visualization
-    Parameters
-    ----------
-    binded: List[tuple]
-        Zipped together binarized facts(0 or 1) and probabilistic prediction
-    Return values
-    -------------
-    result: List[List]
-        Data for lift metric analysis and visualization
-    """
+def calculate_lift_table(binded):
     result = []
     binded.sort(key=lambda item: item[1], reverse=True)
     data_size = len(binded)

--- a/src/evidently/calculations/classification_performance.py
+++ b/src/evidently/calculations/classification_performance.py
@@ -262,6 +262,47 @@ def calculate_pr_table(binded):
         result.append([top, int(count), prob, int(tp), int(fp), precision, recall])
     return result
 
+def calculate_lift_table(binded):
+    result = []
+    binded.sort(key=lambda item: item[1], reverse=True)
+    data_size = len(binded)
+    target_class_size = sum([x[0] for x in binded])
+    offset = max(round(data_size * 0.01), 1)
+
+    for step in np.arange(offset, data_size + offset, offset):
+        count = min(step, data_size)
+        prob = round(binded[min(step, data_size - 1)][1], 2)
+        top = round(100.0 * min(step, data_size) / data_size)
+        tp = sum([x[0] for x in binded[: min(step, data_size)]])
+        fp = count - tp
+        precision = round(100.0 * tp / count, 1)
+        recall = round(100.0 * tp / target_class_size, 1)
+        f1_score = round(2/(1/precision+1/recall), 1)
+        lift = round(recall / top, 2)
+        if count <= target_class_size:
+            max_lift = round(100.0 * count / target_class_size / top, 2)
+        else:
+            max_lift = round(100.0 / top, 2)
+        relative_lift = round(lift / max_lift, 2)
+        percent = round(100 * target_class_size / data_size, 2)
+        result.append(
+            [
+                top,
+                int(count),
+                prob,
+                int(tp),
+                int(fp),
+                precision,
+                recall,
+                f1_score,
+                lift,
+                max_lift,
+                relative_lift,
+                percent,
+            ]
+        )
+    return result
+
 
 def calculate_matrix(target: pd.Series, prediction: pd.Series, labels: List[Union[str, int]]) -> ConfusionMatrix:
     sorted_labels = sorted(labels)

--- a/src/evidently/metrics/classification_performance/lift_curve_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_curve_metric.py
@@ -117,7 +117,7 @@ class ClassificationLiftCurveRenderer(MetricRenderer):
     def render_json(self, obj: ClassificationLiftCurve) -> dict:
         current_lift_curve = obj.get_result().current_lift_curve
         reference_lift_curve = obj.get_result().reference_lift_curve
-        if reference_lift_curve == None:
+        if reference_lift_curve is None:
             return {
                 "current": {
                     "top": current_lift_curve[1]["top"],

--- a/src/evidently/metrics/classification_performance/lift_curve_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_curve_metric.py
@@ -27,22 +27,13 @@ class ClassificationLiftCurveResults:
 
 class ClassificationLiftCurve(Metric[ClassificationLiftCurveResults]):
     def calculate(self, data) -> ClassificationLiftCurveResults:
-        dataset_columns = process_columns(
-            data.current_data, data.column_mapping
-        )
+        dataset_columns = process_columns(data.current_data, data.column_mapping)
         target_name = dataset_columns.utility_columns.target
         prediction_name = dataset_columns.utility_columns.prediction
         if target_name is None or prediction_name is None:
-            raise ValueError(
-                "The columns 'target' and 'prediction' "
-                "columns should be present"
-            )
-        curr_predictions = get_prediction_data(
-            data.current_data, dataset_columns, data.column_mapping.pos_label
-        )
-        curr_lift_curve = self.calculate_metrics(
-            data.current_data[target_name], curr_predictions
-        )
+            raise ValueError("The columns 'target' and 'prediction' " "columns should be present")
+        curr_predictions = get_prediction_data(data.current_data, dataset_columns, data.column_mapping.pos_label)
+        curr_lift_curve = self.calculate_metrics(data.current_data[target_name], curr_predictions)
         ref_lift_curve = None
         if data.reference_data is not None:
             ref_predictions = get_prediction_data(
@@ -50,26 +41,17 @@ class ClassificationLiftCurve(Metric[ClassificationLiftCurveResults]):
                 dataset_columns,
                 data.column_mapping.pos_label,
             )
-            ref_lift_curve = self.calculate_metrics(
-                data.reference_data[target_name], ref_predictions
-            )
+            ref_lift_curve = self.calculate_metrics(data.reference_data[target_name], ref_predictions)
         return ClassificationLiftCurveResults(
             current_lift_curve=curr_lift_curve,
             reference_lift_curve=ref_lift_curve,
         )
 
-    def calculate_metrics(
-        self, target_data: pd.Series, prediction: PredictionData
-    ):
+    def calculate_metrics(self, target_data: pd.Series, prediction: PredictionData):
         labels = prediction.labels
         if prediction.prediction_probas is None:
-            raise ValueError(
-                "Lift Curve can be calculated only "
-                "on binary probabilistic predictions"
-            )
-        binaraized_target = (
-            target_data.values.reshape(-1, 1) == labels
-        ).astype(int)
+            raise ValueError("Lift Curve can be calculated only " "on binary probabilistic predictions")
+        binaraized_target = (target_data.values.reshape(-1, 1) == labels).astype(int)
         lift_curve = {}
         lift_table = {}
         if len(labels) <= 2:
@@ -82,80 +64,21 @@ class ClassificationLiftCurve(Metric[ClassificationLiftCurveResults]):
                     prediction.prediction_probas.iloc[:, 0].tolist(),
                 )
             )
-            lift_table[
-                prediction.prediction_probas.columns[0]
-            ] = calculate_lift_table(binded)
+            lift_table[prediction.prediction_probas.columns[0]] = calculate_lift_table(binded)
 
             lift_curve[prediction.prediction_probas.columns[0]] = {
-                "lift": [
-                    i[8]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "top": [
-                    i[0]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "count": [
-                    i[1]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "prob": [
-                    i[2]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "tp": [
-                    i[3]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "fp": [
-                    i[4]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "precision": [
-                    i[5]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "recall": [
-                    i[6]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "f1_score": [
-                    i[7]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "max_lift": [
-                    i[9]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "relative_lift": [
-                    i[10]
-                    for i in lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ]
-                ],
-                "percent": lift_table[prediction.prediction_probas.columns[0]][
-                    0
-                ][11],
+                "lift": [i[8] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "top": [i[0] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "count": [i[1] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "prob": [i[2] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "tp": [i[3] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "fp": [i[4] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "precision": [i[5] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "recall": [i[6] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "f1_score": [i[7] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "max_lift": [i[9] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "relative_lift": [i[10] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                "percent": lift_table[prediction.prediction_probas.columns[0]][0][11],
             }
         else:
             binaraized_target = pd.DataFrame(binaraized_target)
@@ -173,75 +96,18 @@ class ClassificationLiftCurve(Metric[ClassificationLiftCurveResults]):
             for label in labels:
 
                 lift_curve[prediction.prediction_probas.columns[0]] = {
-                    "lift": [
-                        i[8]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "top": [
-                        i[0]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "count": [
-                        i[1]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "prob": [
-                        i[2]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "tp": [
-                        i[3]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "fp": [
-                        i[4]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "precision": [
-                        i[5]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "recall": [
-                        i[6]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "f1_score": [
-                        i[7]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "max_lift": [
-                        i[9]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "relative_lift": [
-                        i[10]
-                        for i in lift_table[
-                            prediction.prediction_probas.columns[0]
-                        ]
-                    ],
-                    "percent": lift_table[
-                        prediction.prediction_probas.columns[0]
-                    ][0][11],
+                    "lift": [i[8] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "top": [i[0] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "count": [i[1] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "prob": [i[2] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "tp": [i[3] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "fp": [i[4] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "precision": [i[5] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "recall": [i[6] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "f1_score": [i[7] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "max_lift": [i[9] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "relative_lift": [i[10] for i in lift_table[prediction.prediction_probas.columns[0]]],
+                    "percent": lift_table[prediction.prediction_probas.columns[0]][0][11],
                 }
         return lift_curve
 
@@ -251,6 +117,23 @@ class ClassificationLiftCurveRenderer(MetricRenderer):
     def render_json(self, obj: ClassificationLiftCurve) -> dict:
         current_lift_curve = obj.get_result().current_lift_curve
         reference_lift_curve = obj.get_result().reference_lift_curve
+        if reference_lift_curve == None:
+            return {
+                "current": {
+                    "top": current_lift_curve[1]["top"],
+                    "lift": current_lift_curve[1]["lift"],
+                    "count": current_lift_curve[1]["count"],
+                    "prob": current_lift_curve[1]["prob"],
+                    "tp": current_lift_curve[1]["tp"],
+                    "fp": current_lift_curve[1]["fp"],
+                    "precision": current_lift_curve[1]["precision"],
+                    "recall": current_lift_curve[1]["recall"],
+                    "f1_score": current_lift_curve[1]["f1_score"],
+                    "max_lift": current_lift_curve[1]["max_lift"],
+                    "relative_lift": current_lift_curve[1]["relative_lift"],
+                    "percent": current_lift_curve[1]["percent"],
+                },
+            }
         return {
             "current": {
                 "top": current_lift_curve[1]["top"],
@@ -282,9 +165,7 @@ class ClassificationLiftCurveRenderer(MetricRenderer):
             },
         }
 
-    def render_html(
-        self, obj: ClassificationLiftCurve
-    ) -> List[BaseWidgetInfo]:
+    def render_html(self, obj: ClassificationLiftCurve) -> List[BaseWidgetInfo]:
         current_lift_curve = obj.get_result().current_lift_curve
         reference_lift_curve = obj.get_result().reference_lift_curve
         if current_lift_curve is None:

--- a/src/evidently/metrics/classification_performance/lift_curve_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_curve_metric.py
@@ -1,0 +1,304 @@
+import dataclasses
+from typing import List, Optional
+
+import pandas as pd
+from evidently.calculations.classification_performance import (
+    PredictionData,
+    calculate_lift_table,
+    get_prediction_data,
+)
+from evidently.metrics.base_metric import Metric
+from evidently.model.widget import BaseWidgetInfo
+from evidently.renderers.base_renderer import MetricRenderer, default_renderer
+from evidently.renderers.html_widgets import (
+    TabData,
+    get_lift_plot_data,
+    header_text,
+    widget_tabs,
+)
+from evidently.utils.data_operations import process_columns
+
+
+@dataclasses.dataclass
+class ClassificationLiftCurveResults:
+    current_lift_curve: Optional[dict] = None
+    reference_lift_curve: Optional[dict] = None
+
+
+class ClassificationLiftCurve(Metric[ClassificationLiftCurveResults]):
+    def calculate(self, data) -> ClassificationLiftCurveResults:
+        dataset_columns = process_columns(
+            data.current_data, data.column_mapping
+        )
+        target_name = dataset_columns.utility_columns.target
+        prediction_name = dataset_columns.utility_columns.prediction
+        if target_name is None or prediction_name is None:
+            raise ValueError(
+                "The columns 'target' and 'prediction' "
+                "columns should be present"
+            )
+        curr_predictions = get_prediction_data(
+            data.current_data, dataset_columns, data.column_mapping.pos_label
+        )
+        curr_lift_curve = self.calculate_metrics(
+            data.current_data[target_name], curr_predictions
+        )
+        ref_lift_curve = None
+        if data.reference_data is not None:
+            ref_predictions = get_prediction_data(
+                data.reference_data,
+                dataset_columns,
+                data.column_mapping.pos_label,
+            )
+            ref_lift_curve = self.calculate_metrics(
+                data.reference_data[target_name], ref_predictions
+            )
+        return ClassificationLiftCurveResults(
+            current_lift_curve=curr_lift_curve,
+            reference_lift_curve=ref_lift_curve,
+        )
+
+    def calculate_metrics(
+        self, target_data: pd.Series, prediction: PredictionData
+    ):
+        labels = prediction.labels
+        if prediction.prediction_probas is None:
+            raise ValueError(
+                "Lift Curve can be calculated only "
+                "on binary probabilistic predictions"
+            )
+        binaraized_target = (
+            target_data.values.reshape(-1, 1) == labels
+        ).astype(int)
+        lift_curve = {}
+        lift_table = {}
+        if len(labels) <= 2:
+            binaraized_target = pd.DataFrame(binaraized_target[:, 0])
+            binaraized_target.columns = ["target"]
+
+            binded = list(
+                zip(
+                    binaraized_target["target"].tolist(),
+                    prediction.prediction_probas.iloc[:, 0].tolist(),
+                )
+            )
+            lift_table[
+                prediction.prediction_probas.columns[0]
+            ] = calculate_lift_table(binded)
+
+            lift_curve[prediction.prediction_probas.columns[0]] = {
+                "lift": [
+                    i[8]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "top": [
+                    i[0]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "count": [
+                    i[1]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "prob": [
+                    i[2]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "tp": [
+                    i[3]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "fp": [
+                    i[4]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "precision": [
+                    i[5]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "recall": [
+                    i[6]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "f1_score": [
+                    i[7]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "max_lift": [
+                    i[9]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "relative_lift": [
+                    i[10]
+                    for i in lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ]
+                ],
+                "percent": lift_table[prediction.prediction_probas.columns[0]][
+                    0
+                ][11],
+            }
+        else:
+            binaraized_target = pd.DataFrame(binaraized_target)
+            binaraized_target.columns = labels
+
+            for label in labels:
+                binded = list(
+                    zip(
+                        binaraized_target[label].tolist(),
+                        prediction.prediction_probas[label],
+                    )
+                )
+                lift_table[label] = calculate_lift_table(binded)
+
+            for label in labels:
+
+                lift_curve[prediction.prediction_probas.columns[0]] = {
+                    "lift": [
+                        i[8]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "top": [
+                        i[0]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "count": [
+                        i[1]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "prob": [
+                        i[2]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "tp": [
+                        i[3]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "fp": [
+                        i[4]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "precision": [
+                        i[5]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "recall": [
+                        i[6]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "f1_score": [
+                        i[7]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "max_lift": [
+                        i[9]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "relative_lift": [
+                        i[10]
+                        for i in lift_table[
+                            prediction.prediction_probas.columns[0]
+                        ]
+                    ],
+                    "percent": lift_table[
+                        prediction.prediction_probas.columns[0]
+                    ][0][11],
+                }
+        return lift_curve
+
+
+@default_renderer(wrap_type=ClassificationLiftCurve)
+class ClassificationLiftCurveRenderer(MetricRenderer):
+    def render_json(self, obj: ClassificationLiftCurve) -> dict:
+        current_lift_curve = obj.get_result().current_lift_curve
+        reference_lift_curve = obj.get_result().reference_lift_curve
+        return {
+            "current": {
+                "top": current_lift_curve[1]["top"],
+                "lift": current_lift_curve[1]["lift"],
+                "count": current_lift_curve[1]["count"],
+                "prob": current_lift_curve[1]["prob"],
+                "tp": current_lift_curve[1]["tp"],
+                "fp": current_lift_curve[1]["fp"],
+                "precision": current_lift_curve[1]["precision"],
+                "recall": current_lift_curve[1]["recall"],
+                "f1_score": current_lift_curve[1]["f1_score"],
+                "max_lift": current_lift_curve[1]["max_lift"],
+                "relative_lift": current_lift_curve[1]["relative_lift"],
+                "percent": current_lift_curve[1]["percent"],
+            },
+            "reference": {
+                "top": reference_lift_curve[1]["top"],
+                "lift": reference_lift_curve[1]["lift"],
+                "count": reference_lift_curve[1]["count"],
+                "prob": reference_lift_curve[1]["prob"],
+                "tp": reference_lift_curve[1]["tp"],
+                "fp": reference_lift_curve[1]["fp"],
+                "precision": reference_lift_curve[1]["precision"],
+                "recall": reference_lift_curve[1]["recall"],
+                "f1_score": reference_lift_curve[1]["f1_score"],
+                "max_lift": reference_lift_curve[1]["max_lift"],
+                "relative_lift": reference_lift_curve[1]["relative_lift"],
+                "percent": reference_lift_curve[1]["percent"],
+            },
+        }
+
+    def render_html(
+        self, obj: ClassificationLiftCurve
+    ) -> List[BaseWidgetInfo]:
+        current_lift_curve = obj.get_result().current_lift_curve
+        reference_lift_curve = obj.get_result().reference_lift_curve
+        if current_lift_curve is None:
+            return []
+
+        tab_data = get_lift_plot_data(
+            current_lift_curve,
+            reference_lift_curve,
+            color_options=self.color_options,
+        )
+        if len(tab_data) == 1:
+            return [header_text(label="Lift Curve"), tab_data[0][1]]
+        tabs = [TabData(name, widget) for name, widget in tab_data]
+        return [
+            header_text(label="Lift Curve"),
+            widget_tabs(title="", tabs=tabs),
+        ]

--- a/src/evidently/metrics/classification_performance/lift_curve_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_curve_metric.py
@@ -1,21 +1,20 @@
 import dataclasses
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
 import pandas as pd
-from evidently.calculations.classification_performance import (
-    PredictionData,
-    calculate_lift_table,
-    get_prediction_data,
-)
+
+from evidently.calculations.classification_performance import PredictionData
+from evidently.calculations.classification_performance import calculate_lift_table
+from evidently.calculations.classification_performance import get_prediction_data
 from evidently.metrics.base_metric import Metric
 from evidently.model.widget import BaseWidgetInfo
-from evidently.renderers.base_renderer import MetricRenderer, default_renderer
-from evidently.renderers.html_widgets import (
-    TabData,
-    get_lift_plot_data,
-    header_text,
-    widget_tabs,
-)
+from evidently.renderers.base_renderer import MetricRenderer
+from evidently.renderers.base_renderer import default_renderer
+from evidently.renderers.html_widgets import TabData
+from evidently.renderers.html_widgets import get_lift_plot_data
+from evidently.renderers.html_widgets import header_text
+from evidently.renderers.html_widgets import widget_tabs
 from evidently.utils.data_operations import process_columns
 
 

--- a/src/evidently/metrics/classification_performance/lift_table_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_table_metric.py
@@ -1,21 +1,20 @@
 import dataclasses
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
 import pandas as pd
-from evidently.calculations.classification_performance import (
-    PredictionData,
-    calculate_lift_table,
-    get_prediction_data,
-)
+
+from evidently.calculations.classification_performance import PredictionData
+from evidently.calculations.classification_performance import calculate_lift_table
+from evidently.calculations.classification_performance import get_prediction_data
 from evidently.metrics.base_metric import Metric
 from evidently.model.widget import BaseWidgetInfo
-from evidently.renderers.base_renderer import MetricRenderer, default_renderer
-from evidently.renderers.html_widgets import (
-    TabData,
-    WidgetSize,
-    table_data,
-    widget_tabs,
-)
+from evidently.renderers.base_renderer import MetricRenderer
+from evidently.renderers.base_renderer import default_renderer
+from evidently.renderers.html_widgets import TabData
+from evidently.renderers.html_widgets import WidgetSize
+from evidently.renderers.html_widgets import table_data
+from evidently.renderers.html_widgets import widget_tabs
 from evidently.utils.data_operations import process_columns
 
 

--- a/src/evidently/metrics/classification_performance/lift_table_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_table_metric.py
@@ -1,0 +1,198 @@
+import dataclasses
+from typing import List, Optional
+
+import pandas as pd
+from evidently.calculations.classification_performance import (
+    PredictionData,
+    calculate_lift_table,
+    get_prediction_data,
+)
+from evidently.metrics.base_metric import Metric
+from evidently.model.widget import BaseWidgetInfo
+from evidently.renderers.base_renderer import MetricRenderer, default_renderer
+from evidently.renderers.html_widgets import (
+    TabData,
+    WidgetSize,
+    table_data,
+    widget_tabs,
+)
+from evidently.utils.data_operations import process_columns
+
+
+@dataclasses.dataclass
+class ClassificationLiftTableResults:
+    current_lift_table: Optional[dict] = None
+    reference_lift_table: Optional[dict] = None
+    top: Optional[dict] = 10
+
+
+class ClassificationLiftTable(Metric[ClassificationLiftTableResults]):
+    """
+    Evidently metric with inherited behaviour, provides data for lift analysis
+
+    Parameters
+    ----------
+    top: Optional[dict] = 10
+        Limit top percentiles for displaying in report
+
+    """
+
+    top: int
+
+    def __init__(self, top: Optional[int] = 10) -> None:
+        self.top = top
+
+    def calculate(self, data) -> ClassificationLiftTableResults:
+        dataset_columns = process_columns(
+            data.current_data, data.column_mapping
+        )
+        target_name = dataset_columns.utility_columns.target
+        prediction_name = dataset_columns.utility_columns.prediction
+        if target_name is None or prediction_name is None:
+            raise ValueError(
+                (
+                    "The columns 'target' and 'prediction' "
+                    "columns should be present"
+                )
+            )
+        curr_prediction = get_prediction_data(
+            data.current_data, dataset_columns, data.column_mapping.pos_label
+        )
+        curr_lift_table = self.calculate_metrics(
+            data.current_data[target_name], curr_prediction
+        )
+        ref_lift_table = None
+        if data.reference_data is not None:
+            ref_prediction = get_prediction_data(
+                data.reference_data,
+                dataset_columns,
+                data.column_mapping.pos_label,
+            )
+            ref_lift_table = self.calculate_metrics(
+                data.reference_data[target_name], ref_prediction
+            )
+        return ClassificationLiftTableResults(
+            current_lift_table=curr_lift_table,
+            reference_lift_table=ref_lift_table,
+            top=self.top,
+        )
+
+    def calculate_metrics(
+        self, target_data: pd.Series, prediction: PredictionData
+    ):
+        labels = prediction.labels
+        if prediction.prediction_probas is None:
+            raise ValueError(
+                "Lift Table can be calculated only on "
+                "binary probabilistic predictions"
+            )
+        binaraized_target = (
+            target_data.values.reshape(-1, 1) == labels
+        ).astype(int)
+        lift_table = {}
+        if len(labels) <= 2:
+            binaraized_target = pd.DataFrame(binaraized_target[:, 0])
+            binaraized_target.columns = ["target"]
+
+            binded = list(
+                zip(
+                    binaraized_target["target"].tolist(),
+                    prediction.prediction_probas.iloc[:, 0].tolist(),
+                )
+            )
+            lift_table[
+                prediction.prediction_probas.columns[0]
+            ] = calculate_lift_table(binded)
+        else:
+            binaraized_target = pd.DataFrame(binaraized_target)
+            binaraized_target.columns = labels
+
+            for label in labels:
+                binded = list(
+                    zip(
+                        binaraized_target[label].tolist(),
+                        prediction.prediction_probas[label],
+                    )
+                )
+                lift_table[label] = calculate_lift_table(binded)
+        return lift_table
+
+
+@default_renderer(wrap_type=ClassificationLiftTable)
+class ClassificationLiftTableRenderer(MetricRenderer):
+    def render_json(self, obj: ClassificationLiftTable) -> dict:
+        return {}
+
+    def render_html(
+        self, obj: ClassificationLiftTable
+    ) -> List[BaseWidgetInfo]:
+        reference_lift_table = obj.get_result().reference_lift_table
+        current_lift_table = obj.get_result().current_lift_table
+        top = obj.get_result().top
+        columns = [
+            "Top(%)",
+            "Count",
+            "Prob",
+            "TP",
+            "FP",
+            "Precision",
+            "Recall",
+            "F1 score",
+            "Lift",
+            "Max lift",
+            "Relative lift",
+            "Percent",
+        ]
+        result = []
+        size = WidgetSize.FULL
+        if current_lift_table is not None:
+            if len(current_lift_table.keys()) == 1:
+                result.append(
+                    table_data(
+                        column_names=columns,
+                        data=current_lift_table[
+                            list(current_lift_table.keys())[0]
+                        ][:top],
+                        title="Current: Lift Table",
+                        size=size,
+                    )
+                )
+            else:
+                tab_data = []
+                for label in current_lift_table.keys():
+                    table = table_data(
+                        column_names=columns,
+                        data=current_lift_table[label],
+                        title="",
+                        size=size,
+                    )
+                    tab_data.append(TabData(label, table))
+                result.append(
+                    widget_tabs(title="Current: Lift Table", tabs=tab_data)
+                )
+        if reference_lift_table is not None:
+            if len(reference_lift_table.keys()) == 1:
+                result.append(
+                    table_data(
+                        column_names=columns,
+                        data=reference_lift_table[
+                            list(reference_lift_table.keys())[0]
+                        ][:top],
+                        title="Reference: Lift Table",
+                        size=size,
+                    )
+                )
+            else:
+                tab_data = []
+                for label in reference_lift_table.keys():
+                    table = table_data(
+                        column_names=columns,
+                        data=reference_lift_table[label],
+                        title="",
+                        size=size,
+                    )
+                    tab_data.append(TabData(label, table))
+                result.append(
+                    widget_tabs(title="Reference: Lift Table", tabs=tab_data)
+                )
+        return result

--- a/src/evidently/metrics/classification_performance/lift_table_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_table_metric.py
@@ -43,24 +43,13 @@ class ClassificationLiftTable(Metric[ClassificationLiftTableResults]):
         self.top = top
 
     def calculate(self, data) -> ClassificationLiftTableResults:
-        dataset_columns = process_columns(
-            data.current_data, data.column_mapping
-        )
+        dataset_columns = process_columns(data.current_data, data.column_mapping)
         target_name = dataset_columns.utility_columns.target
         prediction_name = dataset_columns.utility_columns.prediction
         if target_name is None or prediction_name is None:
-            raise ValueError(
-                (
-                    "The columns 'target' and 'prediction' "
-                    "columns should be present"
-                )
-            )
-        curr_prediction = get_prediction_data(
-            data.current_data, dataset_columns, data.column_mapping.pos_label
-        )
-        curr_lift_table = self.calculate_metrics(
-            data.current_data[target_name], curr_prediction
-        )
+            raise ValueError(("The columns 'target' and 'prediction' " "columns should be present"))
+        curr_prediction = get_prediction_data(data.current_data, dataset_columns, data.column_mapping.pos_label)
+        curr_lift_table = self.calculate_metrics(data.current_data[target_name], curr_prediction)
         ref_lift_table = None
         if data.reference_data is not None:
             ref_prediction = get_prediction_data(
@@ -68,27 +57,18 @@ class ClassificationLiftTable(Metric[ClassificationLiftTableResults]):
                 dataset_columns,
                 data.column_mapping.pos_label,
             )
-            ref_lift_table = self.calculate_metrics(
-                data.reference_data[target_name], ref_prediction
-            )
+            ref_lift_table = self.calculate_metrics(data.reference_data[target_name], ref_prediction)
         return ClassificationLiftTableResults(
             current_lift_table=curr_lift_table,
             reference_lift_table=ref_lift_table,
             top=self.top,
         )
 
-    def calculate_metrics(
-        self, target_data: pd.Series, prediction: PredictionData
-    ):
+    def calculate_metrics(self, target_data: pd.Series, prediction: PredictionData):
         labels = prediction.labels
         if prediction.prediction_probas is None:
-            raise ValueError(
-                "Lift Table can be calculated only on "
-                "binary probabilistic predictions"
-            )
-        binaraized_target = (
-            target_data.values.reshape(-1, 1) == labels
-        ).astype(int)
+            raise ValueError("Lift Table can be calculated only on " "binary probabilistic predictions")
+        binaraized_target = (target_data.values.reshape(-1, 1) == labels).astype(int)
         lift_table = {}
         if len(labels) <= 2:
             binaraized_target = pd.DataFrame(binaraized_target[:, 0])
@@ -100,9 +80,7 @@ class ClassificationLiftTable(Metric[ClassificationLiftTableResults]):
                     prediction.prediction_probas.iloc[:, 0].tolist(),
                 )
             )
-            lift_table[
-                prediction.prediction_probas.columns[0]
-            ] = calculate_lift_table(binded)
+            lift_table[prediction.prediction_probas.columns[0]] = calculate_lift_table(binded)
         else:
             binaraized_target = pd.DataFrame(binaraized_target)
             binaraized_target.columns = labels
@@ -121,11 +99,91 @@ class ClassificationLiftTable(Metric[ClassificationLiftTableResults]):
 @default_renderer(wrap_type=ClassificationLiftTable)
 class ClassificationLiftTableRenderer(MetricRenderer):
     def render_json(self, obj: ClassificationLiftTable) -> dict:
-        return {}
+        current_lift_table = obj.get_result().current_lift_table
+        reference_lift_table = obj.get_result().reference_lift_table
+        current_lift_table = pd.DataFrame(
+            current_lift_table[1],
+            columns=[
+                "top",
+                "count",
+                "prob",
+                "tp",
+                "fp",
+                "precision",
+                "recall",
+                "f1_score",
+                "lift",
+                "max_lift",
+                "relative_lift",
+                "percent",
+            ],
+        )
+        if reference_lift_table == None:
+            return {
+                "current": {
+                    "top": list(current_lift_table["top"]),
+                    "lift": list(current_lift_table["lift"]),
+                    "count": list(current_lift_table["count"]),
+                    "prob": list(current_lift_table["prob"]),
+                    "tp": list(current_lift_table["tp"]),
+                    "fp": list(current_lift_table["fp"]),
+                    "precision": list(current_lift_table["precision"]),
+                    "recall": list(current_lift_table["recall"]),
+                    "f1_score": list(current_lift_table["f1_score"]),
+                    "max_lift": list(current_lift_table["max_lift"]),
+                    "relative_lift": list(current_lift_table["relative_lift"]),
+                    "percent": current_lift_table["percent"][0],
+                },
+            }
+        reference_lift_table = pd.DataFrame(
+            reference_lift_table[1],
+            columns=[
+                "top",
+                "count",
+                "prob",
+                "tp",
+                "fp",
+                "precision",
+                "recall",
+                "f1_score",
+                "lift",
+                "max_lift",
+                "relative_lift",
+                "percent",
+            ],
+        )
+        return {
+            "current": {
+                "top": list(current_lift_table["top"]),
+                "lift": list(current_lift_table["lift"]),
+                "count": list(current_lift_table["count"]),
+                "prob": list(current_lift_table["prob"]),
+                "tp": list(current_lift_table["tp"]),
+                "fp": list(current_lift_table["fp"]),
+                "precision": list(current_lift_table["precision"]),
+                "recall": list(current_lift_table["recall"]),
+                "f1_score": list(current_lift_table["f1_score"]),
+                "max_lift": list(current_lift_table["max_lift"]),
+                "relative_lift": list(current_lift_table["relative_lift"]),
+                "percent": current_lift_table["percent"][0],
+            },
+            "reference": {
+                "top": list(reference_lift_table["top"]),
+                "lift": list(reference_lift_table["lift"]),
+                "count": list(reference_lift_table["count"]),
+                "prob": list(reference_lift_table["prob"]),
+                "tp": list(reference_lift_table["tp"]),
+                "fp": list(reference_lift_table["fp"]),
+                "precision": list(reference_lift_table["precision"]),
+                "recall": list(reference_lift_table["recall"]),
+                "f1_score": list(reference_lift_table["f1_score"]),
+                "max_lift": list(reference_lift_table["max_lift"]),
+                "relative_lift": list(reference_lift_table["relative_lift"]),
+                "percent": reference_lift_table["percent"][0],
+            },
+        }
 
-    def render_html(
-        self, obj: ClassificationLiftTable
-    ) -> List[BaseWidgetInfo]:
+    def render_html(self, obj: ClassificationLiftTable) -> List[BaseWidgetInfo]:
         reference_lift_table = obj.get_result().reference_lift_table
         current_lift_table = obj.get_result().current_lift_table
         top = obj.get_result().top
@@ -150,9 +208,7 @@ class ClassificationLiftTableRenderer(MetricRenderer):
                 result.append(
                     table_data(
                         column_names=columns,
-                        data=current_lift_table[
-                            list(current_lift_table.keys())[0]
-                        ][:top],
+                        data=current_lift_table[list(current_lift_table.keys())[0]][:top],
                         title="Current: Lift Table",
                         size=size,
                     )
@@ -167,17 +223,13 @@ class ClassificationLiftTableRenderer(MetricRenderer):
                         size=size,
                     )
                     tab_data.append(TabData(label, table))
-                result.append(
-                    widget_tabs(title="Current: Lift Table", tabs=tab_data)
-                )
+                result.append(widget_tabs(title="Current: Lift Table", tabs=tab_data))
         if reference_lift_table is not None:
             if len(reference_lift_table.keys()) == 1:
                 result.append(
                     table_data(
                         column_names=columns,
-                        data=reference_lift_table[
-                            list(reference_lift_table.keys())[0]
-                        ][:top],
+                        data=reference_lift_table[list(reference_lift_table.keys())[0]][:top],
                         title="Reference: Lift Table",
                         size=size,
                     )
@@ -192,7 +244,5 @@ class ClassificationLiftTableRenderer(MetricRenderer):
                         size=size,
                     )
                     tab_data.append(TabData(label, table))
-                result.append(
-                    widget_tabs(title="Reference: Lift Table", tabs=tab_data)
-                )
+                result.append(widget_tabs(title="Reference: Lift Table", tabs=tab_data))
         return result

--- a/src/evidently/metrics/classification_performance/lift_table_metric.py
+++ b/src/evidently/metrics/classification_performance/lift_table_metric.py
@@ -118,7 +118,7 @@ class ClassificationLiftTableRenderer(MetricRenderer):
                 "percent",
             ],
         )
-        if reference_lift_table == None:
+        if reference_lift_table is None:
             return {
                 "current": {
                     "top": list(current_lift_table["top"]),

--- a/src/evidently/renderers/html_widgets.py
+++ b/src/evidently/renderers/html_widgets.py
@@ -812,6 +812,82 @@ def get_pr_rec_plot_data(
     return additional_plots
 
 
+def get_lift_plot_data(
+    current_lift_curve: dict,
+    reference_lift_curve: Optional[dict],
+    color_options: ColorOptions,
+) -> List[Tuple[str, BaseWidgetInfo]]:
+    """
+    Forms plot data for lift metric visualization
+
+    Parameters
+    ----------
+    current_lift_curve: dict
+        Calculated lift table data for current sample
+    reference_lift_curve: Optional[dict]
+        Calculated lift table data for reference sample
+    color_options: ColorOptions
+        Standard Evidently class-collection of colors for data visualization
+
+    Return values
+    -------------
+    additional_plots: List[Tuple[str, BaseWidgetInfo]]
+        Plot objects within List
+    """
+    additional_plots = []
+    cols = 1
+    subplot_titles = [""]
+    if reference_lift_curve is not None:
+        cols = 2
+        subplot_titles = ["current", "reference"]
+    for label in current_lift_curve.keys():
+        fig = make_subplots(rows=1, cols=cols, subplot_titles=subplot_titles, shared_yaxes=True)
+        trace = go.Scatter(
+            x=current_lift_curve[label]["top"],
+            y=current_lift_curve[label]["lift"],
+            mode="lines+markers",
+            name="Lift",
+            hoverinfo="text",
+            text=[
+                f"top: {str(int(current_lift_curve[label]['top'][i]))}, "
+                f"lift={str(current_lift_curve[label]['lift'][i])}"
+                for i in range(100)
+            ],
+            legendgroup="Lift",
+            marker=dict(
+                size=6,
+                color=color_options.get_current_data_color(),
+            ),
+        )
+        fig.add_trace(trace, 1, 1)
+        fig.update_xaxes(title_text="Top", row=1, col=1)
+        if reference_lift_curve is not None:
+            trace = go.Scatter(
+                x=reference_lift_curve[label]["top"],
+                y=reference_lift_curve[label]["lift"],
+                mode="lines+markers",
+                name="Lift",
+                hoverinfo="text",
+                text=[
+                    f"top: {str(int(reference_lift_curve[label]['top'][i]))}, "
+                    f"lift={str(reference_lift_curve[label]['lift'][i])}"
+                    for i in range(100)
+                ],
+                legendgroup="Lift",
+                showlegend=False,
+                marker=dict(
+                    size=6,
+                    color=color_options.get_current_data_color(),
+                ),
+            )
+            fig.add_trace(trace, 1, 2)
+            fig.update_xaxes(title_text="Top", row=1, col=2)
+        fig.update_layout(yaxis_title="Lift", showlegend=True)
+
+        additional_plots.append((str(label), plotly_figure(title="", figure=fig)))
+    return additional_plots
+
+
 def class_separation_traces_raw(df, label, target_name, color_options):
     traces = []
     traces.append(


### PR DESCRIPTION
These commits allow you to add lift table and lift curve metrics to the Evidently common library, all metrics have inherited behavior and integrations of standard Evidently metrics, these metrics were designed by Tokhtakhunov Ilmurat, BigData Analyst of Mobile Advertising and GEO team in the BigData department at Beeline Kazakhstan, as an Evidently library extension for models performance monitoring.