### PR TITLE
Specify UTF-8 as encoding for opening report file

### DIFF
--- a/examples/integrations/streamlit_dashboard/streamlit-app/src/ui.py
+++ b/examples/integrations/streamlit_dashboard/streamlit-app/src/ui.py
@@ -151,7 +151,7 @@ def display_report(report_path: Path) -> List[Text]:
 
     # If a report is file then read and display the report
     if report_path.is_file():
-        with open(report_path, encoding="utf8") as report_f:
+        with open(report_pathdsds, encoding="utf8") as report_f:
             report: Text = report_f.read()
             components.html(report, width=1000, height=1200, scrolling=True)
         return [report]

--- a/examples/integrations/streamlit_dashboard/streamlit-app/src/ui.py
+++ b/examples/integrations/streamlit_dashboard/streamlit-app/src/ui.py
@@ -151,7 +151,7 @@ def display_report(report_path: Path) -> List[Text]:
 
     # If a report is file then read and display the report
     if report_path.is_file():
-        with open(report_path) as report_f:
+        with open(report_path, encoding="utf8") as report_f:
             report: Text = report_f.read()
             components.html(report, width=1000, height=1200, scrolling=True)
         return [report]


### PR DESCRIPTION
Not specifying the encoding resulted in the file failing to be loaded in the streamlit app.