### PR TITLE
Fix target_names type in ConfusionMatrixResult.

### DIFF
--- a/src/evidently/metrics/classification_performance/class_balance_metric.py
+++ b/src/evidently/metrics/classification_performance/class_balance_metric.py
@@ -1,8 +1,7 @@
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Union
-
-import pandas as pd
 
 from evidently.base_metric import InputData
 from evidently.base_metric import Metric
@@ -36,7 +35,11 @@ class ClassificationClassBalance(Metric[ClassificationClassBalanceResult]):
         ref_target = None
         if data.reference_data is not None:
             ref_target = data.reference_data[target_name]
-        target_names = dataset_columns.target_names
+        target_names: Optional[Dict[Union[int, str], str]]
+        if isinstance(dataset_columns.target_names, list):
+            target_names = {idx: str(val) for idx, val in enumerate(dataset_columns.target_names)}
+        else:
+            target_names = dataset_columns.target_names
         if target_names is not None:
             curr_target = curr_target.map(target_names)
             if ref_target is not None:

--- a/src/evidently/metrics/classification_performance/classification_dummy_metric.py
+++ b/src/evidently/metrics/classification_performance/classification_dummy_metric.py
@@ -4,7 +4,6 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
-from sklearn.metrics import classification_report
 from sklearn.metrics import log_loss
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
@@ -121,16 +120,17 @@ class ClassificationDummyMetric(ThresholdClassificationMetric[ClassificationDumm
             coeff_precision = min(1.0, (1 - threshold) / 0.5)
             neg_label_precision = precision_score(target, dummy_preds, pos_label=labels[1]) * coeff_precision
             neg_label_recall = recall_score(target, dummy_preds, pos_label=labels[1]) * coeff_recall
+            f1_label2_value = 2 * neg_label_precision * neg_label_recall / (neg_label_precision + neg_label_recall)
             metrics_matrix = {
                 str(labels[0]): ClassMetric(
                     precision=current_dummy.precision,
                     recall=current_dummy.recall,
-                    f1=current_dummy.f1,
+                    **{"f1-score": current_dummy.f1},
                 ),
                 str(labels[1]): ClassMetric(
                     precision=neg_label_precision,
                     recall=neg_label_recall,
-                    f1=2 * neg_label_precision * neg_label_recall / (neg_label_precision + neg_label_recall),
+                    **{"f1-score": f1_label2_value},
                 ),
             }
         if prediction is not None and prediction.prediction_probas is not None:

--- a/src/evidently/metrics/classification_performance/confusion_matrix_metric.py
+++ b/src/evidently/metrics/classification_performance/confusion_matrix_metric.py
@@ -1,5 +1,3 @@
-import dataclasses
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -10,6 +8,7 @@ from evidently.calculations.classification_performance import calculate_matrix
 from evidently.metric_results import ConfusionMatrix
 from evidently.metrics.classification_performance.base_classification_metric import ThresholdClassificationMetric
 from evidently.model.widget import BaseWidgetInfo
+from evidently.pipeline.column_mapping import TargetNames
 from evidently.renderers.base_renderer import MetricRenderer
 from evidently.renderers.base_renderer import default_renderer
 from evidently.renderers.html_widgets import header_text
@@ -22,7 +21,7 @@ DEFAULT_THRESHOLD = 0.5
 class ClassificationConfusionMatrixResult(MetricResult):
     current_matrix: ConfusionMatrix
     reference_matrix: Optional[ConfusionMatrix]
-    target_names: Optional[Dict[Union[str, int], str]] = None
+    target_names: Optional[TargetNames] = None
 
 
 class ClassificationConfusionMatrix(ThresholdClassificationMetric[ClassificationConfusionMatrixResult]):

--- a/src/evidently/metrics/classification_performance/confusion_matrix_metric.py
+++ b/src/evidently/metrics/classification_performance/confusion_matrix_metric.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -61,7 +62,11 @@ class ClassificationConfusionMatrix(ThresholdClassificationMetric[Classification
 class ClassificationConfusionMatrixRenderer(MetricRenderer):
     def render_html(self, obj: ClassificationConfusionMatrix) -> List[BaseWidgetInfo]:
         metric_result = obj.get_result()
-        target_names = metric_result.target_names
+        target_names: Optional[Dict[Union[int, str], str]]
+        if isinstance(metric_result.target_names, list):
+            target_names = {idx: str(item) for idx, item in enumerate(metric_result.target_names)}
+        else:
+            target_names = metric_result.target_names
         curr_matrix = metric_result.current_matrix
         ref_matrix = metric_result.reference_matrix
         if target_names is not None:

--- a/src/evidently/pipeline/column_mapping.py
+++ b/src/evidently/pipeline/column_mapping.py
@@ -11,7 +11,7 @@ class TaskType:
     CLASSIFICATION_TASK: str = "classification"
 
 
-TargetNames = Union[List[int], List[str], Dict[int, str], Dict[str, str]]
+TargetNames = Union[List[Union[int, str]], Dict[Union[int, str], str]]
 Embeddings = Dict[str, List[str]]
 
 


### PR DESCRIPTION
Changed type of target_names field in ClassificationConfusionMatricResult to Optional[TargetNames] to match source type in ColumnMapping.