### PR TITLE
Exclude python3.7 on macos build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        exclude:
+          - os: macos-latest
+            python: "3.7"
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Exclude configuration due to some bug with packages on macos-latest