### PR TITLE
Update dataset_correlations_metric.py

### DIFF
--- a/src/evidently/metrics/data_quality/dataset_correlations_metric.py
+++ b/src/evidently/metrics/data_quality/dataset_correlations_metric.py
@@ -320,7 +320,7 @@ class DataQualityCorrelationMetricsRenderer(MetricRenderer):
     def render_html(self, obj: DatasetCorrelationsMetric) -> List[BaseWidgetInfo]:
         metric_result = obj.get_result()
         result = [
-            header_text(label="Dataset Correlations Metric"),
+            header_text(label="Dataset Correlations"),
             self._get_heatmaps(metric_result=metric_result),
         ]
         return result


### PR DESCRIPTION
I have changed the display name for DatasetCorrelationsMetric(). Instead of "Dataset Correlations Metric", it should be "Dataset Correlations" in the title.