### PR TITLE
Fix RemoteWorkspace `verify`

### DIFF
--- a/src/evidently/ui/remote.py
+++ b/src/evidently/ui/remote.py
@@ -24,7 +24,7 @@ class RemoteWorkspace(RemoteClientBase, WorkspaceBase[RemoteProject]):
 
     def verify(self):
         try:
-            self._request("/api", "GET").raise_for_status()
+            self._request("/api/", "GET").raise_for_status()
         except HTTPError as e:
             raise ValueError(f"Evidenly API not available at {self.base_url}") from e
 


### PR DESCRIPTION
Add trailing slash in the url path. Without it, initialization of RemoteWorkspace would be stuck in a redirect loop. 

e.g.: 
```
Traceback (most recent call last):
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
  File "<input>", line 1, in <module>
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydev_bundle/pydev_umd.py", line 198, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/vlin/evidently/examples/dummy.py", line 6, in <module>
    workspace = RemoteWorkspace("... redaced ...")
  File "/Users/vlin/evidently/src/evidently/ui/remote.py", line 23, in __init__
    self.verify()
  File "/Users/vlin/evidently/src/evidently/ui/remote.py", line 27, in verify
    self._request("/api", "GET").raise_for_status()
  File "/Users/vlin/evidently/venv/lib/python3.8/site-packages/evidently/ui/utils.py", line 48, in _request
    response = requests.request(
  File "/Users/vlin/evidently/venv/lib/python3.8/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/vlin/evidently/venv/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/vlin/evidently/venv/lib/python3.8/site-packages/requests/sessions.py", line 725, in send
    history = [resp for resp in gen]
  File "/Users/vlin/evidently/venv/lib/python3.8/site-packages/requests/sessions.py", line 725, in <listcomp>
    history = [resp for resp in gen]
  File "/Users/vlin/evidently/venv/lib/python3.8/site-packages/requests/sessions.py", line 191, in resolve_redirects
    raise TooManyRedirects(
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
```


Also confirmed this via `curl`

```
vlin@vlin-mbp evidently % curl -ivl http://localhost:8000/api
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 307 Temporary Redirect
HTTP/1.1 307 Temporary Redirect
< date: Thu, 19 Oct 2023 19:01:19 GMT
date: Thu, 19 Oct 2023 19:01:19 GMT
< server: uvicorn
server: uvicorn
< content-length: 0
content-length: 0
< location: http://localhost:8000/api/
location: http://localhost:8000/api/

<
* Connection #0 to host localhost left intact
```


And confirmed the fix:
```
vlin@vlin-mbp evidently % curl -ivl http://localhost:8000/api/
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api/ HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< date: Thu, 19 Oct 2023 19:01:16 GMT
date: Thu, 19 Oct 2023 19:01:16 GMT
< server: uvicorn
server: uvicorn
< content-length: 25
content-length: 25
< content-type: application/json
content-type: application/json

<
* Connection #0 to host localhost left intact
{"message":"Hello World"}%
```

