### PR TITLE
refactor: Rewrote verify method of RemoteWorkspace

### DIFF
--- a/src/evidently/ui/app.py
+++ b/src/evidently/ui/app.py
@@ -112,7 +112,10 @@ async def root():
 
 @api_read_router.get("/version")
 async def version():
-    return {"version": evidently.__version__}
+    return {
+        "application": "Evidently UI",
+        "version": evidently.__version__,
+    }
 
 
 @api_read_router.get("/projects")

--- a/src/evidently/ui/remote.py
+++ b/src/evidently/ui/remote.py
@@ -1,4 +1,5 @@
 import uuid
+from json.decoder import JSONDecodeError
 from typing import List
 from typing import Optional
 from typing import Union
@@ -24,8 +25,9 @@ class RemoteWorkspace(RemoteClientBase, WorkspaceBase[RemoteProject]):
 
     def verify(self):
         try:
-            self._request("/api/", "GET").raise_for_status()
-        except HTTPError as e:
+            response = self._request("/api/version", "GET")
+            assert response.json()["application"] == "Evidently UI"
+        except (HTTPError, JSONDecodeError, KeyError, AssertionError) as e:
             raise ValueError(f"Evidenly API not available at {self.base_url}") from e
 
     def create_project(self, name: str, description: Optional[str] = None) -> RemoteProject:

--- a/tests/ui/test_ui_basic.py
+++ b/tests/ui/test_ui_basic.py
@@ -23,6 +23,14 @@ def test_root_route():
     assert response.status_code == 200
 
 
+def test_remote_verify_route():
+    response = client.get("/api/version")
+    assert response.status_code == 200
+    version_response = response.json()
+    assert "version" in version_response
+    assert version_response["application"] == "Evidently UI"
+
+
 @pytest.mark.usefixtures("demo_project_workspace")
 def test_api_project():
     response = client.get("/api/projects")


### PR DESCRIPTION
Previously, this method did not check much except HTTP status. This change allows us to properly detect Evidently and also avoid using endpoints with irregular trailing slash.

Closes: #826