### PR TITLE
Fix two FutureWarnings maintaining current behaviour

### DIFF
--- a/src/evidently/calculations/data_integration.py
+++ b/src/evidently/calculations/data_integration.py
@@ -38,8 +38,8 @@ def get_number_of_almost_duplicated_columns(dataset: pd.DataFrame, threshold: fl
 
             # if columns are categorical, then we need to check categories lists
             # if the lists are not the same, Series.eq method raises an exception
-            if pd.api.types.is_categorical_dtype(dataset[column_name_1]) and pd.api.types.is_categorical_dtype(
-                dataset[column_name_2]
+            if isinstance(dataset[column_name_1].dtype, pd.CategoricalDtype) and isinstance(
+                dataset[column_name_2].dtype, pd.CategoricalDtype
             ):
                 if dataset[column_name_1].cat.categories.tolist() != dataset[column_name_2].cat.categories.tolist():
                     continue

--- a/src/evidently/metrics/regression_performance/utils.py
+++ b/src/evidently/metrics/regression_performance/utils.py
@@ -13,12 +13,12 @@ def apply_func_to_binned_data(
     reference = None
     if is_ref_data:
         reference = IntervalSeries.from_data(
-            df_for_bins[df_for_bins.data == "ref"].groupby("target_binned").apply(_apply)
+            df_for_bins[df_for_bins.data == "ref"].groupby("target_binned", observed=False).apply(_apply)
         )
 
     result = RegressionMetricScatter(
         current=IntervalSeries.from_data(
-            df_for_bins[df_for_bins.data == "curr"].groupby("target_binned").apply(_apply)
+            df_for_bins[df_for_bins.data == "curr"].groupby("target_binned", observed=False).apply(_apply)
         ),
         reference=reference,
     )


### PR DESCRIPTION
Fix 2 FutureWarnings
- replace deprecated is_categorical_dtype with isinstance(dtype, pd.CategoricalDtype)
- Explicitly set `observed` parameter to `False` (current default behavior that will change in future) for `groupby`