### PR TITLE
Add RowCountTrigger to Collector Service

### DIFF
--- a/docs/book/monitoring/collector_service.md
+++ b/docs/book/monitoring/collector_service.md
@@ -64,9 +64,11 @@ report_config = ReportConfig.from_test_suite(test_suite)
 
 ## CollectorTrigger
 
-Currently, there is one option available: `IntervalTrigger`. It triggers the snapshot calculation each interval seconds. 
+Currently, there are two options available: 
+* `IntervalTrigger`: triggers the snapshot calculation each interval seconds 
+* `RowsCountTrigger`: triggers the snapshot calculation every time the configured amount of rows have been sent to the collector service
 
-**Note**: we are also working on `CronTrigger` and `RowsCountTrigger`. Would you like to see additional scenarios? Please open a GitHub issue with your suggestions.
+**Note**: we are also working on `CronTrigger` and other triggers. Would you like to see additional scenarios? Please open a GitHub issue with your suggestions.
 
 ## Setup via file
 

--- a/examples/integrations/collector_service/example_report.py
+++ b/examples/integrations/collector_service/example_report.py
@@ -3,18 +3,22 @@ import os.path
 import time
 
 import pandas as pd
-
 from requests.exceptions import RequestException
 
 from evidently.collector.client import CollectorClient
-from evidently.collector.config import CollectorConfig, IntervalTrigger, RowsCountTrigger, ReportConfig
+from evidently.collector.config import CollectorConfig
+from evidently.collector.config import IntervalTrigger
+from evidently.collector.config import ReportConfig
+from evidently.collector.config import RowsCountTrigger
 from evidently.metrics import ColumnValueRangeMetric
 from evidently.report import Report
 from evidently.test_suite import TestSuite
 from evidently.tests import TestNumberOfOutRangeValues
-from evidently.ui.dashboards import DashboardPanelPlot, PanelValue, PlotType, ReportFilter
+from evidently.ui.dashboards import DashboardPanelPlot
+from evidently.ui.dashboards import PanelValue
+from evidently.ui.dashboards import PlotType
+from evidently.ui.dashboards import ReportFilter
 from evidently.ui.workspace import Workspace
-
 
 COLLECTOR_ID = "default"
 COLLECTOR_TEST_ID = "default_test"

--- a/examples/integrations/collector_service/example_report.py
+++ b/examples/integrations/collector_service/example_report.py
@@ -27,7 +27,7 @@ client = CollectorClient("http://localhost:8001")
 
 
 def get_data():
-    cur = ref = pd.DataFrame([{"values1": 5., "values2": 0.} for _ in range(10)])
+    cur = ref = pd.DataFrame([{"values1": 5.0, "values2": 0.0} for _ in range(10)])
     return cur, ref
 
 
@@ -37,6 +37,7 @@ def setup_report():
     cur, ref = get_data()
     report.run(reference_data=ref, current_data=cur)
     return ReportConfig.from_report(report)
+
 
 def setup_test_suite():
     report = TestSuite(tests=[TestNumberOfOutRangeValues("values1", left=5)], tags=["quality"])
@@ -55,7 +56,9 @@ def setup_workspace():
             filter=ReportFilter(metadata_values={}, tag_values=["quality"]),
             values=[
                 PanelValue(metric_id="ColumnValueRangeMetric", field_path="current.share_in_range", legend="current"),
-                PanelValue(metric_id="ColumnValueRangeMetric", field_path="reference.share_in_range", legend="reference"),
+                PanelValue(
+                    metric_id="ColumnValueRangeMetric", field_path="reference.share_in_range", legend="reference"
+                ),
             ],
             plot_type=PlotType.LINE,
         )
@@ -66,12 +69,16 @@ def setup_workspace():
 def setup_config():
     ws = Workspace.create(WORKSPACE_PATH)
     project = ws.search_project(PROJECT_NAME)[0]
-    #conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_report(), project_id=str(project.id))
-    conf = CollectorConfig(trigger=RowsCountTrigger(rows_count=10), report_config=setup_report(), project_id=str(project.id))
+    # conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_report(), project_id=str(project.id))
+    conf = CollectorConfig(
+        trigger=RowsCountTrigger(rows_count=10), report_config=setup_report(), project_id=str(project.id)
+    )
     client.create_collector(id=COLLECTOR_ID, collector=conf)
 
-    #test_conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_test_suite(), project_id=str(project.id))
-    test_conf = CollectorConfig(trigger=RowsCountTrigger(rows_count=10), report_config=setup_test_suite(), project_id=str(project.id))
+    # test_conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_test_suite(), project_id=str(project.id))
+    test_conf = CollectorConfig(
+        trigger=RowsCountTrigger(rows_count=10), report_config=setup_test_suite(), project_id=str(project.id)
+    )
     client.create_collector(id=COLLECTOR_TEST_ID, collector=test_conf)
 
     _, ref = get_data()
@@ -81,7 +88,7 @@ def setup_config():
 
 def send_data():
     size = 1
-    data = pd.DataFrame([{"values1": 3. + datetime.datetime.now().minute % 5, "values2": 0.} for _ in range(size)])
+    data = pd.DataFrame([{"values1": 3.0 + datetime.datetime.now().minute % 5, "values2": 0.0} for _ in range(size)])
 
     client.send_data(COLLECTOR_ID, data)
     client.send_data(COLLECTOR_TEST_ID, data)
@@ -107,5 +114,5 @@ def main():
     start_sending_data()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/integrations/collector_service/example_report.py
+++ b/examples/integrations/collector_service/example_report.py
@@ -7,7 +7,7 @@ import pandas as pd
 from requests.exceptions import RequestException
 
 from evidently.collector.client import CollectorClient
-from evidently.collector.config import CollectorConfig, IntervalTrigger, ReportConfig
+from evidently.collector.config import CollectorConfig, IntervalTrigger, RowsCountTrigger, ReportConfig
 from evidently.metrics import ColumnValueRangeMetric
 from evidently.report import Report
 from evidently.test_suite import TestSuite
@@ -21,7 +21,7 @@ COLLECTOR_TEST_ID = "default_test"
 
 PROJECT_NAME = "My Cool Project"
 
-WORKSACE_PATH = "workspace"
+WORKSPACE_PATH = "workspace"
 
 client = CollectorClient("http://localhost:8001")
 
@@ -47,7 +47,7 @@ def setup_test_suite():
 
 
 def setup_workspace():
-    ws = Workspace.create(WORKSACE_PATH)
+    ws = Workspace.create(WORKSPACE_PATH)
     project = ws.create_project(PROJECT_NAME)
     project.dashboard.add_panel(
         DashboardPanelPlot(
@@ -64,17 +64,19 @@ def setup_workspace():
 
 
 def setup_config():
-    ws = Workspace.create(WORKSACE_PATH)
+    ws = Workspace.create(WORKSPACE_PATH)
     project = ws.search_project(PROJECT_NAME)[0]
-    conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_report(), project_id=str(project.id))
-    client.create_collector(COLLECTOR_ID, conf)
+    #conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_report(), project_id=str(project.id))
+    conf = CollectorConfig(trigger=RowsCountTrigger(rows_count=10), report_config=setup_report(), project_id=str(project.id))
+    client.create_collector(id=COLLECTOR_ID, collector=conf)
 
-    test_conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_test_suite(), project_id=str(project.id))
-    client.create_collector(COLLECTOR_TEST_ID, test_conf)
+    #test_conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_test_suite(), project_id=str(project.id))
+    test_conf = CollectorConfig(trigger=RowsCountTrigger(rows_count=10), report_config=setup_test_suite(), project_id=str(project.id))
+    client.create_collector(id=COLLECTOR_TEST_ID, collector=test_conf)
 
     _, ref = get_data()
-    client.set_reference(COLLECTOR_ID, ref)
-    client.set_reference(COLLECTOR_TEST_ID, ref)
+    client.set_reference(id=COLLECTOR_ID, reference=ref)
+    client.set_reference(id=COLLECTOR_TEST_ID, reference=ref)
 
 
 def send_data():
@@ -97,7 +99,7 @@ def start_sending_data():
 
 
 def main():
-    if not os.path.exists(WORKSACE_PATH) or len(Workspace.create(WORKSACE_PATH).search_project(PROJECT_NAME)) == 0:
+    if not os.path.exists(WORKSPACE_PATH) or len(Workspace.create(WORKSPACE_PATH).search_project(PROJECT_NAME)) == 0:
         setup_workspace()
 
     setup_config()

--- a/examples/integrations/collector_service/example_report.py
+++ b/examples/integrations/collector_service/example_report.py
@@ -75,13 +75,13 @@ def setup_config():
     project = ws.search_project(PROJECT_NAME)[0]
     # conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_report(), project_id=str(project.id))
     conf = CollectorConfig(
-        trigger=RowsCountTrigger(rows_count=10), report_config=setup_report(), project_id=str(project.id)
+        trigger=RowsCountTrigger(rows_count=5), report_config=setup_report(), project_id=str(project.id)
     )
     client.create_collector(id=COLLECTOR_ID, collector=conf)
 
     # test_conf = CollectorConfig(trigger=IntervalTrigger(interval=5), report_config=setup_test_suite(), project_id=str(project.id))
     test_conf = CollectorConfig(
-        trigger=RowsCountTrigger(rows_count=10), report_config=setup_test_suite(), project_id=str(project.id)
+        trigger=RowsCountTrigger(rows_count=5), report_config=setup_test_suite(), project_id=str(project.id)
     )
     client.create_collector(id=COLLECTOR_TEST_ID, collector=test_conf)
 

--- a/src/evidently/collector/config.py
+++ b/src/evidently/collector/config.py
@@ -60,9 +60,7 @@ class RowsCountTrigger(CollectorTrigger):
 
     def is_ready(self, config: "CollectorConfig", storage: "CollectorStorage") -> bool:
         buffer_size = storage.get_buffer_size(config.id)
-        if buffer_size > 0 and buffer_size >= self.rows_count:
-            return True
-        return False
+        return buffer_size > 0 and buffer_size >= self.rows_count
 
 
 class ReportConfig(Config):

--- a/src/evidently/collector/config.py
+++ b/src/evidently/collector/config.py
@@ -63,9 +63,8 @@ class RowsCountTrigger(CollectorTrigger):
         print("RowsCountTrigger")
         print(f"rows_count: {self.rows_count}")
         buffer_size = storage.get_buffer_size(config.id)
-        print(f"buffer length:{buffer_size}")
-        if buffer_size > 0: 
-            if buffer_size % self.rows_count == 0:
+        print(f"buffer length: {buffer_size}")
+        if buffer_size > 0 and buffer_size >= self.rows_count:
                 print("Creating snapshot")
                 return True
         print("Not creating snapshot")

--- a/src/evidently/collector/config.py
+++ b/src/evidently/collector/config.py
@@ -62,9 +62,10 @@ class RowsCountTrigger(CollectorTrigger):
         print("---")
         print("RowsCountTrigger")
         print(f"rows_count: {self.rows_count}")
-        print(f"buffer length:{len(storage._buffers[config.id])}")
-        if len(storage._buffers[config.id]) > 0: 
-            if len(storage._buffers[config.id]) % self.rows_count == 0:
+        buffer_size = storage.get_buffer_size(config.id)
+        print(f"buffer length:{buffer_size}")
+        if buffer_size > 0: 
+            if buffer_size % self.rows_count == 0:
                 print("Creating snapshot")
                 return True
         print("Not creating snapshot")

--- a/src/evidently/collector/config.py
+++ b/src/evidently/collector/config.py
@@ -53,6 +53,22 @@ class IntervalTrigger(CollectorTrigger):
             self.last_triggered = now
             return True
         return False
+    
+
+class RowsCountTrigger(CollectorTrigger):
+    rows_count: int = 1
+
+    def is_ready(self, config: "CollectorConfig", storage: "CollectorStorage") -> bool:
+        print("---")
+        print("RowsCountTrigger")
+        print(f"rows_count: {self.rows_count}")
+        print(f"buffer length:{len(storage._buffers[config.id])}")
+        if len(storage._buffers[config.id]) > 0: 
+            if len(storage._buffers[config.id]) % self.rows_count == 0:
+                print("Creating snapshot")
+                return True
+        print("Not creating snapshot")
+        return False
 
 
 class ReportConfig(Config):

--- a/src/evidently/collector/config.py
+++ b/src/evidently/collector/config.py
@@ -53,21 +53,15 @@ class IntervalTrigger(CollectorTrigger):
             self.last_triggered = now
             return True
         return False
-    
+
 
 class RowsCountTrigger(CollectorTrigger):
     rows_count: int = 1
 
     def is_ready(self, config: "CollectorConfig", storage: "CollectorStorage") -> bool:
-        print("---")
-        print("RowsCountTrigger")
-        print(f"rows_count: {self.rows_count}")
         buffer_size = storage.get_buffer_size(config.id)
-        print(f"buffer length: {buffer_size}")
         if buffer_size > 0 and buffer_size >= self.rows_count:
-                print("Creating snapshot")
-                return True
-        print("Not creating snapshot")
+            return True
         return False
 
 

--- a/src/evidently/collector/storage.py
+++ b/src/evidently/collector/storage.py
@@ -34,7 +34,7 @@ class CollectorStorage(PolymorphicModel):
     @abc.abstractmethod
     def append(self, id: str, data: Any):
         raise NotImplementedError
-    
+
     @abc.abstractmethod
     def get_buffer_size(self, id: str):
         raise NotImplementedError

--- a/src/evidently/collector/storage.py
+++ b/src/evidently/collector/storage.py
@@ -34,6 +34,10 @@ class CollectorStorage(PolymorphicModel):
     @abc.abstractmethod
     def append(self, id: str, data: Any):
         raise NotImplementedError
+    
+    @abc.abstractmethod
+    def get_buffer_size(self, id: str):
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_and_flush(self, id: str):
@@ -61,6 +65,9 @@ class InMemoryStorage(CollectorStorage):
 
     def append(self, id: str, data: Any):
         self._buffers[id].append(data)
+
+    def get_buffer_size(self, id: str):
+        return len(self._buffers[id])
 
     def get_and_flush(self, id: str):
         if id not in self._buffers or len(self._buffers[id]) == 0:


### PR DESCRIPTION
* talking to @elenasamuylova and following https://github.com/evidentlyai/evidently/pull/734 by @mike0sv , I've added a `RowCountTrigger`

For testing:
* go to examples/integrations/collector_service
* run `evidently ui` to run UI service
* run `python src/evidently/collector/app.py` to run collector service
* run `python example_report.py` to configure collector, workspace and report and start sending data
* after someone else has tested the logic: 1) will remove unnecessary prints from `src/evidently/collector/config.py` 2) will remove `RowsCountTrigger` from `examples/integrations/collector_service/example_report.py` and enable `IntervalTrigger` again
![Screenshot 2023-11-25 at 09 52 04](https://github.com/evidentlyai/evidently/assets/139039524/46a99a5e-73ff-4b89-a6dd-ac6b1648ec44)

Additional thoughts:
* safeguard `IntervalTrigger` and `RowsCountTrigger` to not receive negative and zero as value
* I can add the `CronTrigger` or other triggers if needed