### PR TITLE
fix: Fix reference data plot for classification probability distribution

### DIFF
--- a/src/evidently/metrics/classification_performance/probability_distribution_metric.py
+++ b/src/evidently/metrics/classification_performance/probability_distribution_metric.py
@@ -55,27 +55,31 @@ class ClassificationProbDistribution(Metric[ClassificationProbDistributionResult
         if prediction is None:
             raise ValueError("Prediction column should be present")
 
-        prediction_data = get_prediction_data(data.current_data, columns, data.column_mapping.pos_label)
-        if prediction_data.prediction_probas is None:
+        curr_predictions = get_prediction_data(data.current_data, columns, data.column_mapping.pos_label)
+        if curr_predictions.prediction_probas is None:
             current_distribution = None
             reference_distribution = None
 
         else:
             current_data_copy = data.current_data.copy()
-            for col in prediction_data.prediction_probas.columns:
-                current_data_copy[col] = prediction_data.prediction_probas[col]
+            for col in curr_predictions.prediction_probas.columns:
+                current_data_copy[col] = curr_predictions.prediction_probas[col]
 
             current_distribution = self.get_distribution(
-                current_data_copy, target, prediction_data.prediction_probas.columns
+                current_data_copy, target, curr_predictions.prediction_probas.columns
             )
 
             if data.reference_data is not None:
-                reference_data_copy = data.reference_data.copy()
-                for col in prediction_data.prediction_probas.columns:
-                    reference_data_copy[col] = prediction_data.prediction_probas[col]
-                reference_distribution = self.get_distribution(
-                    reference_data_copy, target, prediction_data.prediction_probas.columns
-                )
+                ref_predictions = get_prediction_data(data.reference_data, columns, data.column_mapping.pos_label)
+                if ref_predictions.prediction_probas is None:
+                    reference_distribution = None
+                else:
+                    reference_data_copy = data.reference_data.copy()
+                    for col in ref_predictions.prediction_probas.columns:
+                        reference_data_copy[col] = ref_predictions.prediction_probas[col]
+                    reference_distribution = self.get_distribution(
+                        reference_data_copy, target, ref_predictions.prediction_probas.columns
+                    )
 
             else:
                 reference_distribution = None


### PR DESCRIPTION
## Description
Currently, the `ClassificationProbDistribution.calculate()` method uses the current data predictions to plot the reference probability distribution. This fix updates this so that the reference predictions are plotted correctly.


## Tested
Report tested with the following code:
```python
import pandas as pd

from evidently.metrics import ClassificationProbDistribution
from evidently.report import Report


current_data = pd.DataFrame(data={
    "target": [0, 0, 0, 1, 1, 1],
    "prediction": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
})
reference_data = pd.DataFrame(data={
    "target": [0, 0, 0, 1, 1, 1],
    "prediction": [0.6, 0.7, 0.8, 0.9, 0.9, 0.9],
})

test_report = Report(metrics=[ClassificationProbDistribution()])

test_report.run(reference_data=reference_data, current_data=current_data)
test_report.save_html("test_report_new.html")
```

Current output:
![Screenshot 2023-11-27 at 16 03 30](https://github.com/evidentlyai/evidently/assets/49588411/e63fb063-04c7-4b4a-a7f7-b0cb274441c9)

Fixed output:
![Screenshot 2023-11-27 at 16 05 51](https://github.com/evidentlyai/evidently/assets/49588411/01c626d4-9fff-4a59-9114-55ab76df9cae)
