### PR TITLE
Optimize clf metrics calculation

### DIFF
--- a/src/evidently/calculations/classification_performance.py
+++ b/src/evidently/calculations/classification_performance.py
@@ -383,20 +383,9 @@ def calculate_metrics(
         log_loss = metrics.log_loss(binaraized_target, prediction_probas_array)
         plot_data = collect_plot_data(prediction.prediction_probas)
     if len(prediction.labels) == 2 and prediction.prediction_probas is not None:
-        trues = target == pos_label
-        preds = prediction.prediction_probas[pos_label]
-        preds_inv = 1 - preds
-        fprs, tprs, thrs = metrics.roc_curve(trues, preds)
-        # To get TNRs and FNRs let's swap positive and negative classes in predictions.
-        # `metrics.roc_curve` by default drops intermediate useless points,
-        # but we need the same points here as in the previous call,
-        # so we will select them manually later
-        tnrs_all, fnrs_all, thrs_inv_all = metrics.roc_curve(trues, preds_inv, drop_intermediate=False)
-        thrs_all = 1 - thrs_inv_all[1:]
-        eps = np.finfo(thrs_all.dtype).resolution  # Need this in case of "even" thresholds like `0.2` or `0.325`
-        optimal_ids = np.searchsorted(thrs_all + eps, thrs)  # Get indices of thresholds. They also revert the order
-        tnrs = tnrs_all[optimal_ids]
-        fnrs = fnrs_all[optimal_ids]
+        fprs, tprs, thrs = metrics.roc_curve(target == pos_label, prediction.prediction_probas[pos_label])
+        tnrs = 1 - fprs
+        fnrs = 1 - tprs
         rate_plots_data = RatesPlotData(
             thrs=thrs.tolist(), tpr=tprs.tolist(), fpr=fprs.tolist(), fnr=fnrs.tolist(), tnr=tnrs.tolist()
         )

--- a/tests/calculations/test_classification_performance.py
+++ b/tests/calculations/test_classification_performance.py
@@ -1,6 +1,13 @@
 import numpy as np
+import pandas as pd
+import pytest
+from sklearn import metrics
 
 from evidently.calculations.classification_performance import calculate_confusion_by_classes
+from evidently.calculations.classification_performance import calculate_metrics
+from evidently.metric_results import ConfusionMatrix
+from evidently.metric_results import PredictionData
+from evidently.pipeline.column_mapping import ColumnMapping
 
 
 def test_calculate_confusion_by_classes():
@@ -9,3 +16,44 @@ def test_calculate_confusion_by_classes():
     confusion_by_classes = calculate_confusion_by_classes(confusion_matrix, labels)
     assert confusion_by_classes[labels[0]] == {"tp": 4, "fn": 1, "fp": 2, "tn": 5}
     assert confusion_by_classes[labels[1]] == {"tp": 5, "fn": 2, "fp": 1, "tn": 4}
+
+
+def test_calculate_metrics():
+    prediction_probas = np.array([0.91, 0.82, 0.73, 0.64, 0.55, 0.46, 0.37, 0.28, 0.19, 0.0])
+    target_values = [1, 0, 0, 1, 1, 1, 0, 1, 0, 0]
+    thr = 0.7
+    predictions = (prediction_probas >= thr).astype(int)
+    labels = ["n", "y"]
+    labels_map = dict(zip([0, 1], labels))
+    pos_label = labels[1]
+
+    column_mapping = ColumnMapping(pos_label=pos_label)
+    confusion_matrix = ConfusionMatrix(
+        labels=labels,
+        values=metrics.confusion_matrix(target_values, predictions).tolist(),
+    )
+    target = pd.Series(target_values).map(labels_map)
+    prediction = PredictionData(
+        predictions=pd.Series(predictions).map(labels_map),
+        labels=labels,
+        prediction_probas=pd.DataFrame({labels[0]: 1 - prediction_probas, labels[1]: prediction_probas}),
+    )
+
+    actual_result = calculate_metrics(column_mapping, confusion_matrix, target, prediction)
+
+    assert actual_result.accuracy == pytest.approx(4 / 10)
+    assert actual_result.precision == pytest.approx(1 / 3)
+    assert actual_result.recall == pytest.approx(1 / 5)
+    assert actual_result.f1 == pytest.approx(1 / 4)
+    assert actual_result.tpr == pytest.approx(1 / 5)
+    assert actual_result.tnr == pytest.approx(3 / 5)
+    assert actual_result.fpr == pytest.approx(2 / 5)
+    assert actual_result.fnr == pytest.approx(4 / 5)
+    assert actual_result.roc_auc == pytest.approx(0.64)
+    assert actual_result.log_loss == pytest.approx(0.6884817487155065)
+
+    assert actual_result.rate_plots_data.thrs == [pytest.approx(v) for v in [np.inf, 0.91, 0.73, 0.46, 0.37, 0.28, 0.0]]
+    assert actual_result.rate_plots_data.tpr == [pytest.approx(v) for v in [0.0, 0.2, 0.2, 0.8, 0.8, 1.0, 1.0]]
+    assert actual_result.rate_plots_data.fpr == [pytest.approx(v) for v in [0.0, 0.0, 0.4, 0.4, 0.6, 0.6, 1.0]]
+    assert actual_result.rate_plots_data.fnr == [pytest.approx(v) for v in [1.0, 0.8, 0.8, 0.2, 0.2, 0.0, 0.0]]
+    assert actual_result.rate_plots_data.tnr == [pytest.approx(v) for v in [1.0, 1.0, 0.6, 0.6, 0.4, 0.4, 0.0]]

--- a/tests/calculations/test_classification_performance.py
+++ b/tests/calculations/test_classification_performance.py
@@ -52,7 +52,8 @@ def test_calculate_metrics():
     assert actual_result.roc_auc == pytest.approx(0.64)
     assert actual_result.log_loss == pytest.approx(0.6884817487155065)
 
-    assert actual_result.rate_plots_data.thrs == [pytest.approx(v) for v in [np.inf, 0.91, 0.73, 0.46, 0.37, 0.28, 0.0]]
+    # In `thrs` the 1st elem can be 1.91 or inf depending on version
+    assert actual_result.rate_plots_data.thrs[1:] == [pytest.approx(v) for v in [0.91, 0.73, 0.46, 0.37, 0.28, 0.0]]
     assert actual_result.rate_plots_data.tpr == [pytest.approx(v) for v in [0.0, 0.2, 0.2, 0.8, 0.8, 1.0, 1.0]]
     assert actual_result.rate_plots_data.fpr == [pytest.approx(v) for v in [0.0, 0.0, 0.4, 0.4, 0.6, 0.6, 1.0]]
     assert actual_result.rate_plots_data.fnr == [pytest.approx(v) for v in [1.0, 0.8, 0.8, 0.2, 0.2, 0.0, 0.0]]


### PR DESCRIPTION
Significantly speeded up the calculations in last `if` block in `calculate_metrics` function.

E.g. for 100k rows of random predictions it took 3 mins, now it takes 50 ms (the more data there is, the greater the difference)

Fixes https://github.com/evidentlyai/evidently/issues/508
