### PR TITLE
Bump pydantic version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_args = dict(
         "scipy>=1.5.4",
         "requests>=2.21.0",
         "PyYAML>=5.1",
-        "pydantic<2",
+        "pydantic<3",
         "fastapi>=0.100.0",
         "fastapi-restful>=0.5.0",
         "typing-inspect>=0.9.0",

--- a/tests/utils/test_pydantic_utils.py
+++ b/tests/utils/test_pydantic_utils.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
 import pytest
-from pydantic import parse_obj_as
 
+from evidently._pydantic_compat import parse_obj_as
 from evidently.base_metric import MetricResult
 from evidently.pydantic_utils import PolymorphicModel
 


### PR DESCRIPTION
Issue: https://github.com/evidentlyai/evidently/issues/862

Notes:

upgraded pydantic version to allow versions <3
fixed tests in test_pydantic_utils.py yo use _pydantic_compat.py
increased evidently version so we get a new version