### PR TITLE
Fix `as_frame` parameter

### DIFF
--- a/examples/sample_notebooks/evidently_metric_presets.ipynb
+++ b/examples/sample_notebooks/evidently_metric_presets.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "#Dataset for Data Quality and Integrity\n",
-    "adult_data = datasets.fetch_openml(name='adult', version=2, as_frame='auto')\n",
+    "adult_data = datasets.fetch_openml(name='adult', version=2, as_frame=True)\n",
     "adult = adult_data.frame\n",
     "\n",
     "adult_ref = adult[~adult.education.isin(['Some-college', 'HS-grad', 'Bachelors'])]\n",
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "#Dataset for regression\n",
-    "housing_data = datasets.fetch_california_housing(as_frame='auto')\n",
+    "housing_data = datasets.fetch_california_housing(as_frame=True)\n",
     "housing = housing_data.frame\n",
     "\n",
     "housing.rename(columns={'MedHouseVal': 'target'}, inplace=True)\n",
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "#Dataset for Binary Probabilistic Classifcation\n",
-    "bcancer_data = datasets.load_breast_cancer(as_frame='auto')\n",
+    "bcancer_data = datasets.load_breast_cancer(as_frame=True)\n",
     "bcancer = bcancer_data.frame\n",
     "\n",
     "bcancer_ref = bcancer.sample(n=300, replace=False)\n",
@@ -114,7 +114,7 @@
    "outputs": [],
    "source": [
     "#Dataset for multiclass classifcation\n",
-    "iris_data = datasets.load_iris(as_frame='auto')\n",
+    "iris_data = datasets.load_iris(as_frame=True)\n",
     "iris = iris_data.frame\n",
     "\n",
     "iris_ref = iris.sample(n=150, replace=False)\n",


### PR DESCRIPTION
In recent versions of sklearn (1.4.0), the `as_frame` parameter takes a boolean. For instance, see: https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_iris.html