### PR TITLE
Updated to allow for introspection on GCS buckets

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -23,4 +23,5 @@ fastapi-utils
 uvicorn
 pyarrow
 httpx
+gcsfs
 

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -14,3 +14,5 @@ iterative-telemetry==0.0.5
 watchdog==3.0.0
 pyarrow<11.0dev
 pyspark==3.0.0
+gcsfs==2024.2.0
+

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -14,5 +14,5 @@ iterative-telemetry==0.0.5
 watchdog==3.0.0
 pyarrow<11.0dev
 pyspark==3.0.0
-gcsfs==2024.2.0
+gcsfs==2023.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup_args = dict(
         "rich>=13",
         "iterative-telemetry>=0.0.5",
         "fsspec",
+        "gcsfs",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
This PR allows some introspection utils that allow introspection on Google Cloud Storage Buckets. This allows for storage of the workspace on a GCS bucket provided the user is authenticated to the correct project and auth level for reading. 