### PR TITLE
Feature/add new snapshot trigger and fix collector startup

### DIFF
--- a/tests/collector/test_config.py
+++ b/tests/collector/test_config.py
@@ -1,0 +1,57 @@
+import time
+from typing import Union
+from unittest.mock import Mock
+
+import pytest
+
+from evidently._pydantic_compat import ValidationError
+from evidently.collector.config import IntervalTrigger
+from evidently.collector.config import RowsCountOrIntervalTrigger
+from evidently.collector.config import RowsCountTrigger
+from evidently.collector.storage import CollectorStorage
+
+
+def test_interval_trigger_work():
+    ready_arg = Mock()
+    trigger = IntervalTrigger(interval=0.01)
+    # First check always ready
+    assert trigger.is_ready(ready_arg, ready_arg)
+    assert trigger.is_ready(ready_arg, ready_arg) is False
+    time.sleep(0.01)
+    assert trigger.is_ready(ready_arg, ready_arg)
+
+
+@pytest.mark.parametrize("interval", [0.0, -1.0])
+def test_interval_trigger_invalid_interval(interval: float):
+    with pytest.raises(ValidationError):
+        IntervalTrigger(interval=interval)
+
+
+def test_row_count_trigger_work():
+    storage = Mock(spec=CollectorStorage)
+    storage.get_buffer_size = Mock(side_effect=[0, 1, 0])
+    config = Mock()
+    trigger = RowsCountTrigger(rows_count=1)
+
+    assert trigger.is_ready(config, storage) is False
+    assert trigger.is_ready(config, storage) is True
+    assert trigger.is_ready(config, storage) is False
+
+
+@pytest.mark.parametrize("rows_count", [0.0, -1.0, 0.7])
+def test_rows_count_trigger_invalid_rows_count(rows_count: Union[int, float]):
+    with pytest.raises(ValidationError):
+        RowsCountTrigger(rows_count=rows_count)
+
+
+def test_rows_count_or_interval_trigger_work():
+    storage = Mock(spec=CollectorStorage)
+    storage.get_buffer_size = Mock(side_effect=[1])
+    config = Mock()
+    trigger = RowsCountOrIntervalTrigger(
+        rows_count_trigger=RowsCountTrigger(rows_count=1), interval_trigger=IntervalTrigger(interval=0.1)
+    )
+    # Interval trigger
+    assert trigger.is_ready(config, storage)
+    # Rows count trigger
+    assert trigger.is_ready(config, storage)


### PR DESCRIPTION
Added:  New trigger has been added to initiate a snapshot for the collector based on time or the number of rows
fixed: Collector litestar server cant start https://github.com/evidentlyai/evidently/issues/1012
adde

Also I can't get mypy to run, I've tried Python versions 3.8 and 3.10
```
  File "mypy\main.py", line 95, in main
  File "mypy\main.py", line 174, in run_build
  File "mypy\build.py", line 187, in build
  File "mypy\build.py", line 270, in _build
  File "mypy\build.py", line 2867, in dispatch
  File "mypy\build.py", line 3251, in process_graph
  File "mypy\build.py", line 3372, in process_stale_scc
  File "mypy\build.py", line 2442, in write_cache
  File "mypy\build.py", line 1559, in write_cache
  File "mypy\nodes.py", line 386, in serialize
  File "mypy\nodes.py", line 3649, in serialize
  File "mypy\nodes.py", line 3581, in serialize
AssertionError: Definition of pydantic.types.JsonValue is unexpectedly incomplete
```

TestSuite does not get sent to the collector. After I forcibly called add_tests in TestSuite, the tests can be sent, but the collector cannot run them. I have not yet investigated the reasons
```
def setup_test_suite() -> ReportConfig:
    report = TestSuite(tests=[TestNumberOfOutRangeValues(column_name="values1", left=5), TestValueRange(column_name="values1")], tags=["quality"])
    rep_c =  ReportConfig.from_test_suite(report)
    print(rep_c.dict())
    return rep_c
setup_test_suite()

{'metrics': [], 'tests': [], 'options': {'color': None, 'render': None, 'custom': {}}, 'metadata': {}, 'tags': ['quality']}
```

Automatic generation of the Linestar API specification also does not work.