### PR TITLE
Add k parameter to coverage metric in PopularityBias

### DIFF
--- a/src/evidently/metrics/recsys/popularity_bias.py
+++ b/src/evidently/metrics/recsys/popularity_bias.py
@@ -90,6 +90,18 @@ class PopularityBias(Metric[PopularityBiasResult]):
             (n_items - 1) * np.sum(recommended_counter_sorted)
         )
 
+    def get_coverage(
+        self,
+        k: int,
+        df: pd.DataFrame,
+        train_stats: pd.Series,
+        prediction_name: str,
+        item_name: str,
+    ):
+        return len(np.intersect1d(df[df[prediction_name] <= k][item_name].unique(), train_stats.index)) / len(
+            train_stats
+        )
+
     def calculate(self, data: InputData) -> PopularityBiasResult:
         train_result = self._train_stats.get_result()
         curr_user_interacted = train_result.current
@@ -118,9 +130,7 @@ class PopularityBias(Metric[PopularityBiasResult]):
             user_id,
             item_id,
         )
-        curr_coverage = len(np.intersect1d(current_data[item_id].unique(), curr_user_interacted.index)) / len(
-            curr_user_interacted
-        )
+        curr_coverage = self.get_coverage(self.k, current_data, curr_user_interacted, prediction_name, item_id)
 
         curr_gini = self.get_gini(self.k, current_data, prediction_name, item_id)
 
@@ -151,7 +161,9 @@ class PopularityBias(Metric[PopularityBiasResult]):
 
             ref_gini = self.get_gini(self.k, reference_data, prediction_name, item_id)
         current_distr, reference_distr = get_distribution_for_column(
-            column_type="num", current=current_distr_data, reference=reference_distr_data
+            column_type="num",
+            current=current_distr_data,
+            reference=reference_distr_data,
         )
 
         return PopularityBiasResult(
@@ -177,9 +189,21 @@ class PopularityBiasRenderer(MetricRenderer):
             is_normed = " normilized"
         result = [header_text(label=f"Popularity bias (top-{metric_result.k})")]
         counters = [
-            CounterData.float(label="current ARP" + is_normed, value=metric_result.current_apr, precision=4),
-            CounterData.float(label="current coverage", value=metric_result.current_coverage, precision=4),
-            CounterData.float(label="current gini index", value=metric_result.current_gini, precision=4),
+            CounterData.float(
+                label="current ARP" + is_normed,
+                value=metric_result.current_apr,
+                precision=4,
+            ),
+            CounterData.float(
+                label="current coverage",
+                value=metric_result.current_coverage,
+                precision=4,
+            ),
+            CounterData.float(
+                label="current gini index",
+                value=metric_result.current_gini,
+                precision=4,
+            ),
         ]
         result.append(counter(counters=counters))
         if (
@@ -188,9 +212,21 @@ class PopularityBiasRenderer(MetricRenderer):
             and metric_result.reference_gini is not None
         ):
             counters = [
-                CounterData.float(label="reference ARP" + is_normed, value=metric_result.reference_apr, precision=4),
-                CounterData.float(label="reference coverage", value=metric_result.reference_coverage, precision=4),
-                CounterData.float(label="reference gini index", value=metric_result.reference_gini, precision=4),
+                CounterData.float(
+                    label="reference ARP" + is_normed,
+                    value=metric_result.reference_apr,
+                    precision=4,
+                ),
+                CounterData.float(
+                    label="reference coverage",
+                    value=metric_result.reference_coverage,
+                    precision=4,
+                ),
+                CounterData.float(
+                    label="reference gini index",
+                    value=metric_result.reference_gini,
+                    precision=4,
+                ),
             ]
             result.append(counter(counters=counters))
 

--- a/tests/metrics/recsys/test_popularity_bias.py
+++ b/tests/metrics/recsys/test_popularity_bias.py
@@ -1,9 +1,41 @@
 import pandas as pd
+import pytest
 
 from evidently.metrics import PopularityBias
 from evidently.pipeline.column_mapping import ColumnMapping
 from evidently.pipeline.column_mapping import RecomType
 from evidently.report import Report
+
+
+@pytest.mark.parametrize("k, expected_coverage", ((1, 1 / 3.0), (2, 2 / 3.0), (3, 1.0)))
+def test_coverage(k, expected_coverage):
+    curr = pd.DataFrame(
+        {
+            "user_id": [1, 1, 1, 2, 2, 2, 3, 3, 3],
+            "item_id": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+            "prediction": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+        }
+    )
+
+    train = pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 3],
+            "item_id": [1, 2, 1, 3],
+        }
+    )
+
+    metric = PopularityBias(k=k)
+    report = Report(metrics=[metric])
+    column_mapping = ColumnMapping(recommendations_type=RecomType.RANK)
+    report.run(
+        reference_data=None,
+        current_data=curr,
+        column_mapping=column_mapping,
+        additional_data={"current_train_data": train},
+    )
+
+    results = metric.get_result()
+    assert results.current_coverage == expected_coverage
 
 
 def test_curr_rank():


### PR DESCRIPTION
Fixing issue #945 
Added `k` parameter to Coverage metric calculation as described in the [docs](https://docs.evidentlyai.com/reference/all-metrics/ranking-metrics#id-2.-coverage).
Added test showcasing the fix effect.