### PR TITLE
fix(evidently-ui): secret token auth always failing

### DIFF
--- a/src/evidently/ui/security/token.py
+++ b/src/evidently/ui/security/token.py
@@ -29,6 +29,6 @@ class TokenSecurity(SecurityService):
         self.config = config
 
     def authenticate(self, request: Request) -> Optional[User]:
-        if request.headers.get(SECRET_HEADER_NAME) == self.config.token:
+        if request.headers.get(SECRET_HEADER_NAME) == self.config.token.get_secret_value():
             return default_user
         return None


### PR DESCRIPTION
This commit fixes an issue where using secret token authentication (by specifying an `EVIDENTLY_SECRET` in the environment, which blocks access to WRITE endpoints (e.g. POST snapshots) with the `evidently ui` monitoring service would always fail, returning a 403 Forbidden despite the client using the correct password.