### PR TITLE
Fix: Encode str to bytes before writing to buffered IO

### DIFF
--- a/src/evidently/suite/base_suite.py
+++ b/src/evidently/suite/base_suite.py
@@ -1,6 +1,7 @@
 import abc
 import copy
 import dataclasses
+import io
 import json
 import logging
 import uuid
@@ -257,8 +258,12 @@ class Display:
             if isinstance(filename, str):
                 with open(filename, "w", encoding="utf-8") as out_file:
                     out_file.write(render)
-            else:
+            elif isinstance(filename, io.BytesIO):
+                filename.write(render.encode(encoding="utf-8"))
+            elif isinstance(filename, io.StringIO):
                 filename.write(render)
+            else:
+                raise ValueError("filename should be a string or file-like object")
         else:
             if not isinstance(filename, str):
                 raise ValueError("Only singlefile save mode supports streams")


### PR DESCRIPTION
If you try something like this:
```
html_buffer = BytesIO()
report.save_html(html_buffer)
```
where report is 
```
report = Report(
    metrics=[
        DataDriftPreset(),
    ]
)
```
after a successful `report.run`

You'll get:
```
TypeError: a bytes-like object is required, not 'str'
```
due to the fact that `render` in `filename.write(render)` is a string, not bytes. 
In this PR, I'm encoding render to bytes before writing to the buffer.