### PR TITLE
Fix `datasets.load_iris` parameter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ from sklearn import datasets
 from evidently.test_suite import TestSuite
 from evidently.test_preset import DataStabilityTestPreset
 
-iris_data = datasets.load_iris(as_frame='auto')
+iris_data = datasets.load_iris(as_frame=True)
 iris_frame = iris_data.frame
 ```
 
@@ -142,7 +142,7 @@ from sklearn import datasets
 from evidently.report import Report
 from evidently.metric_preset import DataDriftPreset
 
-iris_data = datasets.load_iris(as_frame='auto')
+iris_data = datasets.load_iris(as_frame=True)
 iris_frame = iris_data.frame
 ```
 


### PR DESCRIPTION
## Problem description

`evidently` requires `scikit-learn>=1.0.1` ([source](https://github.com/evidentlyai/evidently/blob/042790c29ac3709b5dc2d33f578fe2da45225566/setup.py#L56)), but since `scikit-learn` version `1.3.0` (PR https://github.com/scikit-learn/scikit-learn/pull/26177), the command

```python
from sklearn import datasets

iris_data = datasets.load_iris(as_frame='auto')
```

raises the following error:

```python
InvalidParameterError: The 'as_frame' parameter of load_iris must be an instance of 'bool', an instance of 'numpy.bool_' or an instance of 'int'. Got 'auto' instead.
```

## Proposed changes

Changing the command to `iris_data = datasets.load_iris(as_frame=True)` fixes the error, and `iris_frame = iris_data.frame` returns a `pandas.DataFrame`.