### PR TITLE
Fix zero percentage replacement in get_binned_data Function and update parameter name

### DIFF
--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -39,20 +39,15 @@ def get_binned_data(
         current_percents = np.array([current_feature_dict[key] / len(current_data) for key in keys])
 
     if feel_zeroes:
-        np.place(
-            reference_percents,
-            reference_percents == 0,
-            min(reference_percents[reference_percents != 0]) / 10**6
-            if min(reference_percents[reference_percents != 0]) <= 0.0001
-            else 0.0001,
-        )
-        np.place(
-            current_percents,
-            current_percents == 0,
-            min(current_percents[current_percents != 0]) / 10**6
-            if min(current_percents[current_percents != 0]) <= 0.0001
-            else 0.0001,
-        )
+        min_non_zero_ref = np.min(reference_percents[reference_percents != 0])
+        min_non_zero_cur = np.min(current_percents[current_percents != 0])
+
+        fill_value = min(min_non_zero_ref, min_non_zero_cur) / 10
+
+        fill_value = min(fill_value, min(min_non_zero_ref, min_non_zero_cur) / 2)
+
+        np.place(reference_percents, reference_percents == 0, fill_value)
+        np.place(current_percents, current_percents == 0, fill_value)
 
     return reference_percents, current_percents
 

--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -12,7 +12,7 @@ def get_unique_not_nan_values_list_from_series(current_data: pd.Series, referenc
 
 
 def get_binned_data(
-    reference_data: pd.Series, current_data: pd.Series, feature_type: ColumnType, n: int, feel_zeroes: bool = True
+    reference_data: pd.Series, current_data: pd.Series, feature_type: ColumnType, n: int, fill_zeroes: bool = True
 ):
     """Split variable into n buckets based on reference quantiles
     Args:
@@ -38,7 +38,7 @@ def get_binned_data(
         reference_percents = np.array([ref_feature_dict[key] / len(reference_data) for key in keys])
         current_percents = np.array([current_feature_dict[key] / len(current_data) for key in keys])
 
-    if feel_zeroes:
+    if fill_zeroes:
         min_non_zero_ref = np.min(reference_percents[reference_percents != 0])
         min_non_zero_cur = np.min(current_percents[current_percents != 0])
 


### PR DESCRIPTION
This pull request introduces changes that address the issue: `The fixed value for feel_zeroes in get_binned_data may lead to deviation in some case. #334`

- **Dynamic Fill Value Calculation:** The fill value used to replace zero percentages is now calculated dynamically based on the actual data, rather than using a fixed value.

- **Ensuring Correct Fill Value:** The fill value is guaranteed to be smaller than the minimum non-zero percentage in both the reference and current datasets. This adjustment ensures that the data distribution remains accurate.

- **Maintaining Data Distribution:** These changes help maintain the correct distribution of data, which is crucial for accurate statistical tests, including Kullback-Leibler divergence drift score calculations.

- **Parameter Name Update:** The parameter name has been updated from "feel_zeroes" to "fill_zeroes" for clarity and consistency.

Hope it helps
[boemer00](https://github.com/boemer00)