### PR TITLE
Docs: change `TextOverviewPreset` to `TextEvals`

### DIFF
--- a/docs/book/presets/text-overview.md
+++ b/docs/book/presets/text-overview.md
@@ -1,6 +1,6 @@
 **TL;DR:** You can explore and compare text datasets.
 
-* **Report**: for visual analysis or metrics export, use the `TextOverviewPreset`.
+* **Report**: for visual analysis or metrics export, use the `TextEvals`.
 
 # Use case 
 
@@ -14,13 +14,13 @@ You can evaluate and explore text data:
 
 # Text Overview Report   
 
-If you want to visually explore the text data, you can create a new Report object and use the `TextOverviewPreset`.
+If you want to visually explore the text data, you can create a new Report object and use the `TextEvals`.
 
 ## Code example
 
 ```python
 text_overview_report = Report(metrics=[
-    TextOverviewPreset(column_name="Review_Text")
+    TextEvals(column_name="Review_Text")
 ])
 
 text_overview_report.run(reference_data=ref, current_data=cur)
@@ -38,7 +38,7 @@ nltk.download('omw-1.4')
 
 ## How it works
 
-The `TextOverviewPreset` provides an overview and comparison of text datasets.
+The `TextEvals` provides an overview and comparison of text datasets.
 * Generates a **descriptive summary** of the text columns in the dataset. 
 * Performs **data drift detection** to compare the two texts using the domain classifier approach. 
 * Shows distributions of the **text descriptors** in two datasets, and their **correlations** with other features. 

--- a/docs/book/reference/all-metrics.md
+++ b/docs/book/reference/all-metrics.md
@@ -147,28 +147,6 @@ How to set [data drift parameters](../customization/options-for-statistical-test
 
 </details>
 
-<details>
-  
-<summary>Text Overview Preset</summary>
-
-`TextOverviewPreset()` provides a summary for a single or multiple text columns. Text columns are required.
-
-**Composition**:
-* `ColumnSummaryMetric()` for text descriptors for all columns. Descriptors included:
-  * `Sentiment()`
-  * `SentenceCount()`
-  * `OOV()`
-  * `TextLength()`
-  * `NonLetterCharacterPercentage()` 
-* `SemanticSimilarity()` between each pair of text columns, if there is more than one. 
-
-**Required parameters**:
-* `column_name` or `columns` list
-
-**Optional parameters**:
-* `descriptors` list
-
-</details>
 
 <details>
   
@@ -186,6 +164,9 @@ How to set [data drift parameters](../customization/options-for-statistical-test
   
 **Required parameters**:
 * `column_name`
+
+**Optional parameters**:
+* `descriptors` list
 
 </details>
 


### PR DESCRIPTION
On this page
https://docs.evidentlyai.com/presets/text-overview
there are references to a `TextOverviewPreset` class which does not seem to exist in the library. Instead I am fairly confident that instead it should be the `TextEvals` preset.