### PR TITLE
Fix Recommender Rank Metric Preset In `recsys.py`

### DIFF
--- a/src/evidently/metric_preset/recsys.py
+++ b/src/evidently/metric_preset/recsys.py
@@ -102,7 +102,7 @@ class RecsysPreset(MetricPreset):
         if is_train_data:
             metrics.append(PopularityBias(k=self.k, normalize_arp=self.normalize_arp))
         metrics.append(RecCasesTable(user_ids=self.user_ids, display_features=self.display_features))
-        if data_definition.recommendations_type == RecomType.RANK:
+        if data_definition.recommendations_type == RecomType.SCORE:
             metrics.append(ScoreDistribution(k=self.k))
         metrics.append(PersonalizationMetric(k=self.k))
         if self.item_features is not None:


### PR DESCRIPTION
Hi, I have followed through the notebook of https://github.com/evidentlyai/evidently/blob/main/examples/how_to_questions/how_to_run_recsys_metrics.ipynb

I had an error in the `RecsysPreset` class when running the code section of:

```py
report = Report(metrics=[
    RecsysPreset(
        k=5,
        display_features=['action', 'adventure', 'animation'],
        item_features=item_features,
        user_bias_columns=['age', 'gender'],
        item_bias_columns=['moive_age', 'crime'],
    )
])
column_mapping = ColumnMapping(recommendations_type='rank', target='rating', prediction='rank', item_id='title', user_id='user_id')
report.run(
    reference_data=most_popular_df.dropna(subset=['title', 'user_id']).fillna(0),
    current_data=als_df.dropna(subset=['title', 'user_id']).fillna(0),
    column_mapping=column_mapping,
    additional_data={'current_train_data': train.dropna(subset=['title', 'user_id'])}
  )
report
```

This is the error:

```
[/usr/local/lib/python3.11/dist-packages/evidently/metrics/recsys/scores_distribution.py](https://localhost:8080/#) in calculate(self, data)
     77     def calculate(self, data: InputData) -> ScoreDistributionResult:
     78         if data.column_mapping.recom_type == RecomType.RANK:
---> 79             raise ValueError("ScoreDistribution metric is only defined when recommendations_type equals 'scores'.")
     80         prediction_name = get_prediciton_name(data)
     81         user_id = data.column_mapping.user_id

ValueError: ScoreDistribution metric is only defined when recommendations_type equals 'scores'.
<evidently.report.report.Report at 0x7fcfd155ec50>
```

### Solution

The happens because the `ScoreDistribution` metric expects a recommendation_type of `RecomType.SCORE` (and not `RecomType.RANK`).
I am afraid this was a typo in the library.
I made a commit to fix the problem.

Thank you!