### PR TITLE
Add test params to regression presets.

### DIFF
--- a/src/evidently/future/metric_types.py
+++ b/src/evidently/future/metric_types.py
@@ -23,6 +23,7 @@ from typing import Union
 
 import typing_inspect
 
+from evidently._pydantic_compat import BaseModel
 from evidently.future._utils import not_implemented
 from evidently.future.datasets import Dataset
 from evidently.metric_results import Label
@@ -986,6 +987,11 @@ class MeanStdBoundTest(BoundTest[MeanStdValue]):
             calculation,
             metric_result.get_mean() if self.is_mean else metric_result.get_std(),
         )
+
+
+class MeanStdMetricTests(BaseModel):
+    mean: SingleValueMetricTests = None
+    std: SingleValueMetricTests = None
 
 
 class MeanStdMetric(Metric["MeanStdCalculation"]):

--- a/src/evidently/future/presets/regression.py
+++ b/src/evidently/future/presets/regression.py
@@ -116,6 +116,8 @@ class RegressionDummyQuality(MetricContainer):
 
 
 class RegressionPreset(MetricContainer):
+    _quality: Optional[RegressionQuality] = None
+
     def __init__(
         self,
         mean_error_tests: Optional[MeanStdMetricTests] = None,

--- a/src/evidently/future/presets/regression.py
+++ b/src/evidently/future/presets/regression.py
@@ -154,6 +154,8 @@ class RegressionPreset(MetricContainer):
         ]
 
     def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+        if self._quality is None:
+            raise ValueError("No _quality set in preset, something went wrong.")
         return (
             self._quality.render(context, results)
             + context.get_metric_result(

--- a/tests/future/presets/regression.py
+++ b/tests/future/presets/regression.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import pytest
+
+from evidently.future.datasets import DataDefinition
+from evidently.future.datasets import Dataset
+from evidently.future.datasets import Regression
+from evidently.future.metric_types import MeanStdMetricTests
+from evidently.future.presets import RegressionQuality
+from evidently.future.report import Report
+from evidently.future.tests import lt
+
+
+@pytest.mark.parametrize(
+    "preset,expected_tests",
+    [
+        (RegressionQuality(), 0),
+        (RegressionQuality(mean_error_tests=MeanStdMetricTests(mean=[lt(0.1)])), 1),
+        (RegressionQuality(mean_error_tests=MeanStdMetricTests(std=[lt(0.1)])), 1),
+        (RegressionQuality(mae_tests=MeanStdMetricTests(mean=[lt(0.1)])), 1),
+        (RegressionQuality(mae_tests=MeanStdMetricTests(std=[lt(0.1)])), 1),
+        (RegressionQuality(mape_tests=MeanStdMetricTests(mean=[lt(0.1)])), 1),
+        (RegressionQuality(mape_tests=MeanStdMetricTests(std=[lt(0.1)])), 1),
+        (RegressionQuality(rmse_tests=[lt(0.1)]), 1),
+        (RegressionQuality(r2score_tests=[lt(0.1)]), 1),
+        (RegressionQuality(abs_max_error_tests=[lt(0.1)]), 1),
+    ],
+)
+def test_regression_quality_preset_tests(preset, expected_tests):
+    report = Report([preset])
+    dataset = Dataset.from_pandas(
+        pd.DataFrame(data=dict(target=[1, 2, 3, 4, 5], prediction=[0, 1, 2, 3, 4])),
+        data_definition=DataDefinition(regression=[Regression()]),
+    )
+    snapshot = report.run(dataset)
+    snapshot_data = snapshot.dict()
+    assert len(snapshot_data["tests"]) == expected_tests


### PR DESCRIPTION
1) Add new type `MeanStdMetricTests` to provide tests to MeanStdMetric
Example:
```python
tests = MeanStdMetricTests(mean=[lt(0.1)])
```
will pass test `lt(0.1)` to `mean` value of corresponding metric.

2) Add tests parameters to regression presets:
- `RegressionQuality()` / `RegressionPreset()`
  - `mean_error_tests` - (optional) if set to MeanStdMetricTests objects - tests passed to `MeanError` metric.
  - `mape_tests` - (optional) if set to MeanStdMetricTests objects - tests passed to `MAPE` metric.
  - `rmse_tests` - (optional) if set to SingleValueMetricTests objects - tests passed to `RMSE` metric.
  - `mae_tests` - (optional) if set to MeanStdMetricTests objects - tests passed to `MAE` metric.
  - `r2score_tests` - (optional) if set to SingleValueMetricTests objects - tests passed to `R2Score` metric.
  - `abs_max_error_tests` - (optional) if set to SingleValueMetricTests objects - tests passed to `AbsMaxError` metric.
- `RegressionDummyQuality()`
  - `mape_tests` - (optional) if set to SingleValueMetricTests objects - tests passed to `DummyMAPE` metric.
  - `rmse_tests` - (optional) if set to SingleValueMetricTests objects - tests passed to `DummyRMSE` metric.
  - `mae_tests` - (optional) if set to SingleValueMetricTests objects - tests passed to `DummyMAE` metric.