### PR TITLE
Fix ValueStats for binary category column.

### DIFF
--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -9,7 +9,6 @@ from evidently.core import ColumnType
 from evidently.future.container import MetricContainer
 from evidently.future.metric_types import ByLabelCountValue
 from evidently.future.metric_types import ByLabelMetricTests
-from evidently.future.metric_types import ByLabelValue
 from evidently.future.metric_types import Metric
 from evidently.future.metric_types import MetricId
 from evidently.future.metric_types import MetricResult
@@ -269,7 +268,7 @@ class ValueStats(MetricContainer):
 
     def _most_common_value(self, unique_value: MetricResult):
         if not isinstance(unique_value, ByLabelCountValue):
-            raise ValueError("Most common value must be of type 'ByLabelValue'")
+            raise ValueError("Most common value must be of type 'ByLabelCountValue'")
         first = sorted(unique_value.counts.items(), key=lambda x: x[1], reverse=True)[0]
         return f"Label: {first[0]} count: {first[1]}"
 
@@ -280,16 +279,16 @@ class ValueStats(MetricContainer):
         label: Label,
     ):
         result = context.get_metric_result(metric)
-        assert isinstance(result, ByLabelValue)
+        assert isinstance(result, ByLabelCountValue)
         if context.has_reference:
             ref_result = context.get_reference_metric_result(metric)
-            assert isinstance(ref_result, ByLabelValue)
+            assert isinstance(ref_result, ByLabelCountValue)
             return [
-                str(result.values[label]),
-                str(ref_result.values[label]),
+                f"{result.counts[label]} ({(result.shares[label] * 100):0.0f}%)",
+                f"{ref_result.counts[label]} ({(ref_result.shares[label] * 100):0.0f}%)",
             ]
         return [
-            str(result.values[label]),
+            f"{result.counts[label]} ({(result.shares[label] * 100):0.0f}%)",
         ]
 
 

--- a/tests/future/presets/dataset_stats.py
+++ b/tests/future/presets/dataset_stats.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import pytest
+
+from evidently.future.datasets import DataDefinition
+from evidently.future.datasets import Dataset
+from evidently.future.presets import ValueStats
+from evidently.future.report import Report
+
+
+@pytest.mark.parametrize(
+    "dataset,column,expected_metric_count",
+    [
+        (
+            Dataset.from_pandas(
+                pd.DataFrame(data=dict(column=[1, 1, 1, 1, 0])),
+                data_definition=DataDefinition(categorical_columns=["column"]),
+            ),
+            "column",
+            3,
+        ),
+    ],
+)
+def test_value_stats(dataset, column, expected_metric_count):
+    report = Report([ValueStats(column=column)])
+    snapshot = report.run(dataset, None)
+    assert len(snapshot.dict()["metrics"]) == expected_metric_count


### PR DESCRIPTION
Fix exception:
```
...
/usr/local/lib/python3.11/dist-packages/evidently/future/presets/dataset_stats.py in <listcomp>(.0)
    218                     {
    219                         "label": f"{label}",
--> 220                         "values": self._label_count(context, unique_value_count, label),
    221                     }
    222                     for label in context.column(self._column).labels()

/usr/local/lib/python3.11/dist-packages/evidently/future/presets/dataset_stats.py in _label_count(self, context, metric, label)
    281     ):
    282         result = context.get_metric_result(metric)
--> 283         assert isinstance(result, ByLabelValue)
    284         if context.has_reference:
    285             ref_result = context.get_reference_metric_result(metric)

AssertionError: 
```

 in ValueStats preset for Binary Categorical columns during construction render.