### PR TITLE
Fix value in CategoryCount for constant columns.

### DIFF
--- a/src/evidently/future/metrics/column_statistics.py
+++ b/src/evidently/future/metrics/column_statistics.py
@@ -250,9 +250,7 @@ class CategoryCountCalculation(CountCalculation[CategoryCount]):
         column = dataset.column(self.metric.column)
         try:
             counts = column.data.value_counts()
-            if len(counts) == len(self.metric.categories):
-                value = len(column.data)
-            elif all(isinstance(c, bool) for c in self.metric.categories):
+            if all(isinstance(c, bool) for c in self.metric.categories):
                 value = counts[self.metric.categories[0]]  # only one boolean label is possible here
             else:
                 value = counts.loc[self.metric.categories].sum()  # type: ignore[index]

--- a/tests/future/metrics/category_count.py
+++ b/tests/future/metrics/category_count.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pytest
+
+from evidently.future.datasets import Dataset
+from evidently.future.metric_types import CountValue
+from evidently.future.metrics import CategoryCount
+from evidently.future.report import Report
+
+
+@pytest.mark.parametrize(
+    "data,category,expected_count",
+    [
+        (["a", "a", "a"], "a", 3),
+        (["a", "a", "a"], "b", 0),
+        ([True, True, True], True, 3),
+        ([True, True, True], False, 0),
+        ([True, True, None], True, 2),
+        ([True, True, None], False, 0),
+        ([False, False, None], False, 2),
+    ],
+)
+def test_category_count_metric(data, category, expected_count):
+    dataset = Dataset.from_pandas(pd.DataFrame(data=dict(column=data)))
+    metric = CategoryCount("column", category=category)
+    report = Report([metric])
+    snapshot = report.run(dataset, None)
+    metric_result = snapshot._context.get_metric_result(metric.metric_id)
+    assert isinstance(metric_result, CountValue)
+    assert metric_result.count == expected_count


### PR DESCRIPTION
CategoryCount metrics incorrectly calculate count for column with single value in it and if requested category isn't it.