### PR TITLE
recursive metric containers

### DIFF
--- a/src/evidently/future/container.py
+++ b/src/evidently/future/container.py
@@ -1,26 +1,28 @@
 import abc
 import itertools
-import typing
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
+from typing import Union
 
 from evidently.future.metric_types import Metric
 from evidently.future.metric_types import MetricId
 from evidently.future.metric_types import MetricResult
 from evidently.model.widget import BaseWidgetInfo
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from evidently.future.report import Context
 
-MetricOrContainer = typing.Union[Metric, "MetricContainer"]
+MetricOrContainer = Union[Metric, "MetricContainer"]
 
 
 class MetricContainer(abc.ABC):
     _metrics: Optional[List[Metric]] = None
 
     @abc.abstractmethod
-    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
+    def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         raise NotImplementedError()
 
     def metrics(self, context: "Context") -> List[Metric]:

--- a/src/evidently/future/container.py
+++ b/src/evidently/future/container.py
@@ -14,7 +14,7 @@ if typing.TYPE_CHECKING:
     from evidently.future.report import Context
 
 
-class MetricContainer:
+class MetricContainer(abc.ABC):
     _metrics: Optional[List[Metric]] = None
 
     @abc.abstractmethod
@@ -30,3 +30,8 @@ class MetricContainer:
         if self._metrics is None:
             raise ValueError("Metrics weren't composed in container")
         return list(itertools.chain(*[results[metric.to_calculation().id].widget for metric in self._metrics]))
+
+
+class ColumnMetricContainer(MetricContainer, abc.ABC):
+    def __init__(self, column: str):
+        self._column = column

--- a/src/evidently/future/generators/column.py
+++ b/src/evidently/future/generators/column.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import List
 from typing import Literal
 from typing import Optional
+from typing import Sequence
 from typing import Type
 from typing import Union
 
@@ -32,7 +33,7 @@ class ColumnMetricGenerator(MetricContainer):
     def _instantiate_metric(self, column: str) -> MetricOrContainer:
         return self.metric_type(column=column, **self.metric_kwargs)
 
-    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
+    def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         if self.columns is not None:
             column_list = self.columns
         else:

--- a/src/evidently/future/generators/column.py
+++ b/src/evidently/future/generators/column.py
@@ -9,8 +9,8 @@ from typing import Union
 from evidently import ColumnType
 from evidently.future.container import ColumnMetricContainer
 from evidently.future.container import MetricContainer
+from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import ColumnMetric
-from evidently.future.metric_types import Metric
 from evidently.future.report import Context
 
 ColumnTypeStr = Union[ColumnType, str]
@@ -29,10 +29,10 @@ class ColumnMetricGenerator(MetricContainer):
         self.column_types = column_types
         self.metric_kwargs = metric_kwargs or {}
 
-    def _instantiate_metric(self, column: str) -> Union[Metric, MetricContainer]:
+    def _instantiate_metric(self, column: str) -> MetricOrContainer:
         return self.metric_type(column=column, **self.metric_kwargs)
 
-    def generate_metrics(self, context: "Context") -> List[Metric]:
+    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
         if self.columns is not None:
             column_list = self.columns
         else:

--- a/src/evidently/future/generators/column.py
+++ b/src/evidently/future/generators/column.py
@@ -7,6 +7,7 @@ from typing import Type
 from typing import Union
 
 from evidently import ColumnType
+from evidently.future.container import ColumnMetricContainer
 from evidently.future.container import MetricContainer
 from evidently.future.metric_types import ColumnMetric
 from evidently.future.metric_types import Metric
@@ -18,7 +19,7 @@ ColumnTypeStr = Union[ColumnType, str]
 class ColumnMetricGenerator(MetricContainer):
     def __init__(
         self,
-        metric_type: Type[ColumnMetric],
+        metric_type: Union[Type[ColumnMetric], Type[ColumnMetricContainer]],
         columns: Optional[List[str]] = None,
         column_types: Union[ColumnTypeStr, List[ColumnTypeStr], Literal["all"]] = "all",
         metric_kwargs: Optional[Dict[str, Any]] = None,
@@ -28,7 +29,7 @@ class ColumnMetricGenerator(MetricContainer):
         self.column_types = column_types
         self.metric_kwargs = metric_kwargs or {}
 
-    def _instantiate_metric(self, column: str) -> Metric:
+    def _instantiate_metric(self, column: str) -> Union[Metric, MetricContainer]:
         return self.metric_type(column=column, **self.metric_kwargs)
 
     def generate_metrics(self, context: "Context") -> List[Metric]:

--- a/src/evidently/future/metrics/group_by.py
+++ b/src/evidently/future/metrics/group_by.py
@@ -3,6 +3,7 @@ from typing import Optional
 from typing import Sequence
 
 from evidently.future.container import MetricContainer
+from evidently.future.container import MetricOrContainer
 from evidently.future.datasets import Dataset
 from evidently.future.metric_types import BoundTest
 from evidently.future.metric_types import Metric
@@ -50,7 +51,7 @@ class GroupBy(MetricContainer):
         self._column_name = column_name
         self._metric = metric
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         labels = context.column(self._column_name).labels()
         return [GroupByMetric(metric=self._metric, column_name=self._column_name, label=label) for label in labels]
 

--- a/src/evidently/future/metrics/group_by.py
+++ b/src/evidently/future/metrics/group_by.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Optional
 from typing import Sequence
 
@@ -51,7 +50,7 @@ class GroupBy(MetricContainer):
         self._column_name = column_name
         self._metric = metric
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         labels = context.column(self._column_name).labels()
         return [GroupByMetric(metric=self._metric, column_name=self._column_name, label=label) for label in labels]
 

--- a/src/evidently/future/preset_types.py
+++ b/src/evidently/future/preset_types.py
@@ -1,11 +1,6 @@
-import abc
 import dataclasses
-from typing import Dict
 from typing import List
 
-from evidently.future.metric_types import Metric
-from evidently.future.metric_types import MetricId
-from evidently.future.metric_types import MetricResult
 from evidently.future.metric_types import render_widgets
 from evidently.model.widget import BaseWidgetInfo
 
@@ -16,13 +11,3 @@ class PresetResult:
 
     def _repr_html_(self):
         return render_widgets(self.widget)
-
-
-class MetricPreset:
-    @abc.abstractmethod
-    def metrics(self) -> List[Metric]:
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def calculate(self, metric_results: Dict[MetricId, MetricResult]) -> PresetResult:
-        raise NotImplementedError()

--- a/src/evidently/future/presets/classification.py
+++ b/src/evidently/future/presets/classification.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 from evidently.future.container import MetricContainer
 from evidently.future.container import MetricOrContainer
@@ -72,7 +73,7 @@ class ClassificationQuality(MetricContainer):
         self._pr_curve = pr_curve
         self._pr_table = pr_table
 
-    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
+    def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         classification = context.data_definition.get_classification("default")
         if classification is None:
             raise ValueError("Cannot use ClassificationQuality without a classification data")
@@ -148,7 +149,7 @@ class ClassificationQualityByLabel(MetricContainer):
         self._recall_tests = recall_tests
         self._rocauc_tests = rocauc_tests
 
-    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
+    def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         classification = context.data_definition.get_classification("default")
         if classification is None:
             raise ValueError("Cannot use ClassificationPreset without a classification configration")
@@ -185,7 +186,7 @@ class ClassificationDummyQuality(MetricContainer):
         self._probas_threshold = probas_threshold
         self._k = k
 
-    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
+    def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         return [
             DummyPrecision(),
             DummyRecall(),
@@ -250,7 +251,7 @@ class ClassificationPreset(MetricContainer):
             tests=rocauc_tests,
         )
 
-    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
+    def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         classification = context.data_definition.get_classification("default")
         if classification is None:
             raise ValueError("Cannot use ClassificationPreset without a classification configration")

--- a/src/evidently/future/presets/classification.py
+++ b/src/evidently/future/presets/classification.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Optional
 
 from evidently.future.container import MetricContainer
+from evidently.future.container import MetricOrContainer
 from evidently.future.datasets import BinaryClassification
 from evidently.future.metric_types import ByLabelMetricTests
 from evidently.future.metric_types import Metric
@@ -71,7 +72,7 @@ class ClassificationQuality(MetricContainer):
         self._pr_curve = pr_curve
         self._pr_table = pr_table
 
-    def generate_metrics(self, context: "Context") -> List[Metric]:
+    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
         classification = context.data_definition.get_classification("default")
         if classification is None:
             raise ValueError("Cannot use ClassificationQuality without a classification data")
@@ -147,7 +148,7 @@ class ClassificationQualityByLabel(MetricContainer):
         self._recall_tests = recall_tests
         self._rocauc_tests = rocauc_tests
 
-    def generate_metrics(self, context: "Context") -> List[Metric]:
+    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
         classification = context.data_definition.get_classification("default")
         if classification is None:
             raise ValueError("Cannot use ClassificationPreset without a classification configration")
@@ -184,7 +185,7 @@ class ClassificationDummyQuality(MetricContainer):
         self._probas_threshold = probas_threshold
         self._k = k
 
-    def generate_metrics(self, context: "Context") -> List[Metric]:
+    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
         return [
             DummyPrecision(),
             DummyRecall(),
@@ -249,7 +250,7 @@ class ClassificationPreset(MetricContainer):
             tests=rocauc_tests,
         )
 
-    def generate_metrics(self, context: "Context") -> List[Metric]:
+    def generate_metrics(self, context: "Context") -> List[MetricOrContainer]:
         classification = context.data_definition.get_classification("default")
         if classification is None:
             raise ValueError("Cannot use ClassificationPreset without a classification configration")

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -8,6 +8,7 @@ from typing import Optional
 from evidently.core import ColumnType
 from evidently.future.container import ColumnMetricContainer
 from evidently.future.container import MetricContainer
+from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import ByLabelCountValue
 from evidently.future.metric_types import ByLabelMetricTests
 from evidently.future.metric_types import Metric
@@ -67,7 +68,7 @@ class ValueStats(ColumnMetricContainer):
         self._q75_tests = q75_tests
         self._unique_values_count_tests = unique_values_count_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         metrics: List[Metric] = [
             RowCount(tests=self._row_count_tests),
             MissingValueCount(column=self._column, tests=self._missing_values_count_tests),
@@ -318,7 +319,7 @@ class DatasetStats(MetricContainer):
         self.column_count_tests = column_count_tests
         self.row_count_tests = row_count_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         return [
             RowCount(tests=self.row_count_tests),
             ColumnCount(tests=self.column_count_tests),
@@ -370,7 +371,7 @@ class TextEvals(MetricContainer):
         self._row_count_tests = row_count_tests
         self._column_tests = column_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         if self._columns is None:
             cols = context.data_definition.numerical_descriptors + context.data_definition.categorical_descriptors
         else:
@@ -418,7 +419,7 @@ class DataSummaryPreset(MetricContainer):
         self._columns = columns
         self._column_tests = column_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         columns_ = context.data_definition.get_categorical_columns() + context.data_definition.get_numerical_columns()
         self._dataset_stats = DatasetStats(
             row_count_tests=self.row_count_tests,

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -4,6 +4,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 from evidently.core import ColumnType
 from evidently.future.container import ColumnMetricContainer
@@ -68,7 +69,7 @@ class ValueStats(ColumnMetricContainer):
         self._q75_tests = q75_tests
         self._unique_values_count_tests = unique_values_count_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         metrics: List[Metric] = [
             RowCount(tests=self._row_count_tests),
             MissingValueCount(column=self._column, tests=self._missing_values_count_tests),
@@ -319,7 +320,7 @@ class DatasetStats(MetricContainer):
         self.column_count_tests = column_count_tests
         self.row_count_tests = row_count_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         return [
             RowCount(tests=self.row_count_tests),
             ColumnCount(tests=self.column_count_tests),
@@ -371,7 +372,7 @@ class TextEvals(MetricContainer):
         self._row_count_tests = row_count_tests
         self._column_tests = column_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         if self._columns is None:
             cols = context.data_definition.numerical_descriptors + context.data_definition.categorical_descriptors
         else:
@@ -419,7 +420,7 @@ class DataSummaryPreset(MetricContainer):
         self._columns = columns
         self._column_tests = column_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         columns_ = context.data_definition.get_categorical_columns() + context.data_definition.get_numerical_columns()
         self._dataset_stats = DatasetStats(
             row_count_tests=self.row_count_tests,

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Optional
 
 from evidently.core import ColumnType
+from evidently.future.container import ColumnMetricContainer
 from evidently.future.container import MetricContainer
 from evidently.future.metric_types import ByLabelCountValue
 from evidently.future.metric_types import ByLabelMetricTests
@@ -39,7 +40,7 @@ from evidently.model.widget import link_metric
 from evidently.renderers.html_widgets import rich_data
 
 
-class ValueStats(MetricContainer):
+class ValueStats(ColumnMetricContainer):
     def __init__(
         self,
         column: str,
@@ -54,7 +55,7 @@ class ValueStats(MetricContainer):
         q75_tests: SingleValueMetricTests = None,
         unique_values_count_tests: ByLabelMetricTests = None,
     ):
-        self._column = column
+        super().__init__(column=column)
         self._row_count_tests = row_count_tests
         self._missing_values_count_tests = missing_values_count_tests
         self._min_tests = min_tests

--- a/src/evidently/future/presets/drift.py
+++ b/src/evidently/future/presets/drift.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 from evidently.calculations.stattests import PossibleStatTestType
 from evidently.calculations.stattests import StatTest
@@ -53,7 +54,7 @@ class DataDriftPreset(MetricContainer):
         self.embeddings = embeddings
         self.columns = columns
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         types = [ColumnType.Numerical, ColumnType.Categorical, ColumnType.Text]
         options = DataDriftOptions(
             drift_share=self.drift_share,

--- a/src/evidently/future/presets/drift.py
+++ b/src/evidently/future/presets/drift.py
@@ -6,7 +6,7 @@ from evidently.calculations.stattests import PossibleStatTestType
 from evidently.calculations.stattests import StatTest
 from evidently.core import ColumnType
 from evidently.future.container import MetricContainer
-from evidently.future.metric_types import Metric
+from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import MetricId
 from evidently.future.metric_types import MetricResult
 from evidently.future.metrics import ValueDrift
@@ -53,7 +53,7 @@ class DataDriftPreset(MetricContainer):
         self.embeddings = embeddings
         self.columns = columns
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         types = [ColumnType.Numerical, ColumnType.Categorical, ColumnType.Text]
         options = DataDriftOptions(
             drift_share=self.drift_share,

--- a/src/evidently/future/presets/regression.py
+++ b/src/evidently/future/presets/regression.py
@@ -3,8 +3,8 @@ from typing import List
 from typing import Optional
 
 from evidently.future.container import MetricContainer
+from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import MeanStdMetricTests
-from evidently.future.metric_types import Metric
 from evidently.future.metric_types import MetricId
 from evidently.future.metric_types import MetricResult
 from evidently.future.metric_types import SingleValueMetricTests
@@ -51,7 +51,7 @@ class RegressionQuality(MetricContainer):
         self._r2score_tests = r2score_tests
         self._abs_max_error_tests = abs_max_error_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         return [
             MeanError(mean_tests=self._mean_error_tests.mean, std_tests=self._mean_error_tests.std),
             MAPE(mean_tests=self._mape_tests.mean, std_tests=self._mape_tests.std),
@@ -97,7 +97,7 @@ class RegressionDummyQuality(MetricContainer):
         self._mape_tests = mape_tests
         self._rmse_tests = rmse_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         return [
             DummyMAE(tests=self._mae_tests),
             DummyMAPE(tests=self._mape_tests),
@@ -135,7 +135,7 @@ class RegressionPreset(MetricContainer):
         self._r2score_tests = r2score_tests
         self._abs_max_error_tests = abs_max_error_tests
 
-    def generate_metrics(self, context: Context) -> List[Metric]:
+    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
         self._quality = RegressionQuality(
             True,
             True,

--- a/src/evidently/future/presets/regression.py
+++ b/src/evidently/future/presets/regression.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 from evidently.future.container import MetricContainer
 from evidently.future.container import MetricOrContainer
@@ -51,7 +52,7 @@ class RegressionQuality(MetricContainer):
         self._r2score_tests = r2score_tests
         self._abs_max_error_tests = abs_max_error_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         return [
             MeanError(mean_tests=self._mean_error_tests.mean, std_tests=self._mean_error_tests.std),
             MAPE(mean_tests=self._mape_tests.mean, std_tests=self._mape_tests.std),
@@ -97,7 +98,7 @@ class RegressionDummyQuality(MetricContainer):
         self._mape_tests = mape_tests
         self._rmse_tests = rmse_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         return [
             DummyMAE(tests=self._mae_tests),
             DummyMAPE(tests=self._mape_tests),
@@ -135,7 +136,7 @@ class RegressionPreset(MetricContainer):
         self._r2score_tests = r2score_tests
         self._abs_max_error_tests = abs_max_error_tests
 
-    def generate_metrics(self, context: Context) -> List[MetricOrContainer]:
+    def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         self._quality = RegressionQuality(
             True,
             True,


### PR DESCRIPTION
**Pull Request Description**

This PR introduces improvements and changes to the metric generation framework within the Evidently library. Notable changes include the implementation of `MetricOrContainer` type, which allows metrics and their containers to coexist seamlessly. Multiple classes, including `MetricContainer`, `ColumnMetricContainer`, and various preset metrics, have been updated to utilize this new type, enhancing the flexibility and adaptability of the metric generation process.

### Summary of Changes:
- Added the `MetricOrContainer` type to support both metrics and metric containers.
- Refactored several classes to return a sequence of `MetricOrContainer` instead of just `Metric`.
- Updated the `ColumnMetricGenerator` to work with both `ColumnMetric` and `ColumnMetricContainer`.

### Example Usage:
To use the `ColumnMetricGenerator` with the `ValueStats` preset, you can instantiate and call it as follows:

```python
from evidently.future.generators.column import ColumnMetricGenerator
from evidently.future.presets.dataset_stats import ValueStats

# Initialize the ColumnMetricGenerator
column_metric_generator = ColumnMetricGenerator(
    metric_type=ValueStats,
    columns=["column_name_here"]
)

# Generate metrics
metrics = column_metric_generator.generate_metrics(context)
```

This structure allows for more sophisticated metrics generation and integration, paving the way for future enhancements in the Evidently framework.