### PR TITLE
Fix The cardinality of column (<column>) has been exceeded for small datasets.

### DIFF
--- a/src/evidently/utils/data_preprocessing.py
+++ b/src/evidently/utils/data_preprocessing.py
@@ -144,7 +144,7 @@ def _is_cardinality_exceeded(
     limit: Optional[int],
 ) -> bool:
     cardinality = _get_column_cardinality(column_name, data)
-    if limit and cardinality >= min(limit, data.current.shape[0]):
+    if limit and cardinality >= limit:
         return True
     return False
 


### PR DESCRIPTION
When amount of unique values is equal to amount of rows in datasets you can get an error "The cardinality of column (<column>) has been exceeded".

Remove comparison with rows amount in cardinality check.