### PR TITLE
Proper render of containers inside containers and generators.

### DIFF
--- a/src/evidently/future/container.py
+++ b/src/evidently/future/container.py
@@ -37,7 +37,7 @@ class MetricContainer(abc.ABC):
     ) -> List[BaseWidgetInfo]:
         if self._metrics is None:
             raise ValueError("Metrics weren't composed in container")
-        return list(itertools.chain(*[widget[1] for widget in child_widgets]))
+        return list(itertools.chain(*[widget[1] for widget in (child_widgets or [])]))
 
     def list_metrics(self) -> Generator[Metric, None, None]:
         if self._metrics is None:

--- a/src/evidently/future/generators/column.py
+++ b/src/evidently/future/generators/column.py
@@ -1,9 +1,11 @@
+from itertools import chain
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Literal
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 from typing import Type
 from typing import Union
 
@@ -12,7 +14,9 @@ from evidently.future.container import ColumnMetricContainer
 from evidently.future.container import MetricContainer
 from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import ColumnMetric
+from evidently.future.metric_types import MetricId
 from evidently.future.report import Context
+from evidently.model.widget import BaseWidgetInfo
 
 ColumnTypeStr = Union[ColumnType, str]
 
@@ -46,3 +50,10 @@ class ColumnMetricGenerator(MetricContainer):
             cts: List[ColumnType] = [ct if isinstance(ct, ColumnType) else ColumnType(ct) for ct in column_types]
             column_list = list(context.data_definition.get_columns(cts))
         return [self._instantiate_metric(column) for column in column_list]
+
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
+        return list(chain(*[widget[1] for widget in child_widgets]))

--- a/src/evidently/future/generators/column.py
+++ b/src/evidently/future/generators/column.py
@@ -56,4 +56,4 @@ class ColumnMetricGenerator(MetricContainer):
         context: "Context",
         child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
     ) -> List[BaseWidgetInfo]:
-        return list(chain(*[widget[1] for widget in child_widgets]))
+        return list(chain(*[widget[1] for widget in (child_widgets or [])]))

--- a/src/evidently/future/presets/classification.py
+++ b/src/evidently/future/presets/classification.py
@@ -1,7 +1,7 @@
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 from evidently.future.container import MetricContainer
 from evidently.future.container import MetricOrContainer
@@ -9,7 +9,6 @@ from evidently.future.datasets import BinaryClassification
 from evidently.future.metric_types import ByLabelMetricTests
 from evidently.future.metric_types import Metric
 from evidently.future.metric_types import MetricId
-from evidently.future.metric_types import MetricResult
 from evidently.future.metric_types import SingleValueMetricTests
 from evidently.future.metrics import FNR
 from evidently.future.metrics import FPR
@@ -104,7 +103,11 @@ class ClassificationQuality(MetricContainer):
             )
         return metrics
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         _, render = context.get_legacy_metric(
             ClassificationQualityMetric(probas_threshold=self._probas_threshold),
             _gen_classification_input_data,
@@ -127,7 +130,7 @@ class ClassificationQuality(MetricContainer):
                 ClassificationPRTable(probas_threshold=self._probas_threshold),
                 _gen_classification_input_data,
             )[1]
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(render, metric)
         return render
 
@@ -165,14 +168,18 @@ class ClassificationQualityByLabel(MetricContainer):
             ]
         )
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]):
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         render = context.get_legacy_metric(
             ClassificationQualityByClass(self._probas_threshold, self._k),
             _gen_classification_input_data,
         )[1]
         widget = render
         widget[0].params["counters"][0]["label"] = "Classification Quality by Label"
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(widget, metric)
         return widget
 
@@ -193,12 +200,16 @@ class ClassificationDummyQuality(MetricContainer):
             DummyF1Score(),
         ]
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         _, widgets = context.get_legacy_metric(
             ClassificationDummyMetric(self._probas_threshold, self._k),
             _gen_classification_input_data,
         )
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(widgets, metric)
         return widgets
 
@@ -263,9 +274,13 @@ class ClassificationPreset(MetricContainer):
             + ([] if self._roc_auc is None else [RocAuc(probas_threshold=self._probas_threshold)])
         )
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         return (
-            self._quality.render(context, results)
-            + self._quality_by_label.render(context, results)
+            self._quality.render(context)
+            + self._quality_by_label.render(context)
             + ([] if self._roc_auc is None else context.get_metric_result(self._roc_auc).widget)
         )

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -386,7 +386,7 @@ class TextEvals(MetricContainer):
             cols = context.data_definition.numerical_descriptors + context.data_definition.categorical_descriptors
         else:
             cols = self._columns
-        metrics: List[Metric] = [RowCount(tests=self._row_count_tests)]
+        metrics: List[MetricOrContainer] = [RowCount(tests=self._row_count_tests)]
         self._value_stats = [
             ValueStats(column, **(self._column_tests or {}).get(column, ValueStatsTests()).__dict__) for column in cols
         ]

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 from evidently.core import ColumnType
 from evidently.future.container import ColumnMetricContainer
@@ -96,7 +97,11 @@ class ValueStats(ColumnMetricContainer):
             ]
         return metrics
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         column_type = context.column(self._column).column_type
         widgets = []
         if column_type == ColumnType.Numerical:
@@ -110,7 +115,7 @@ class ValueStats(ColumnMetricContainer):
             widgets = self._render_datetime(context)
         if column_type == ColumnType.Text:
             widgets = self._render_text(context)
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(widgets, metric)
         return widgets
 
@@ -338,10 +343,14 @@ class DatasetStats(MetricContainer):
             DatasetMissingValueCount(tests=self.dataset_missing_value_count_tests),
         ]
 
-    def render(self, context: Context, results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         metric = DatasetSummaryMetric()
         _, render = context.get_legacy_metric(metric, _default_input_data_generator)
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(render, metric)
         return render
 
@@ -384,8 +393,12 @@ class TextEvals(MetricContainer):
         metrics.extend(list(chain(*[vs.metrics(context)[1:] for vs in self._value_stats])))
         return metrics
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
-        return list(chain(*[vs.render(context, results) for vs in self._value_stats]))
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
+        return list(chain(*[vs.render(context) for vs in self._value_stats]))
 
 
 class DataSummaryPreset(MetricContainer):
@@ -437,7 +450,11 @@ class DataSummaryPreset(MetricContainer):
         self._text_evals = TextEvals(self._columns or columns_, column_tests=self._column_tests)
         return self._dataset_stats.metrics(context) + self._text_evals.metrics(context)
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         if self._dataset_stats is None or self._text_evals is None:
             raise ValueError("Inconsistent internal state for DataSummaryPreset")
-        return self._dataset_stats.render(context, results) + self._text_evals.render(context, results)
+        return self._dataset_stats.render(context) + self._text_evals.render(context)

--- a/src/evidently/future/presets/drift.py
+++ b/src/evidently/future/presets/drift.py
@@ -2,6 +2,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 from evidently.calculations.stattests import PossibleStatTestType
 from evidently.calculations.stattests import StatTest
@@ -9,7 +10,6 @@ from evidently.core import ColumnType
 from evidently.future.container import MetricContainer
 from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import MetricId
-from evidently.future.metric_types import MetricResult
 from evidently.future.metrics import ValueDrift
 from evidently.future.metrics.column_statistics import DriftedColumnsCount
 from evidently.future.report import Context
@@ -98,7 +98,11 @@ class DataDriftPreset(MetricContainer):
             for column in (self.columns if self.columns is not None else context.data_definition.get_columns(types))
         ]
 
-    def render(self, context: Context, results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         dataset_drift = context.get_legacy_metric(
             DatasetDriftMetric(
                 columns=self.columns,

--- a/src/evidently/future/presets/regression.py
+++ b/src/evidently/future/presets/regression.py
@@ -1,13 +1,12 @@
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 from evidently.future.container import MetricContainer
 from evidently.future.container import MetricOrContainer
 from evidently.future.metric_types import MeanStdMetricTests
 from evidently.future.metric_types import MetricId
-from evidently.future.metric_types import MetricResult
 from evidently.future.metric_types import SingleValueMetricTests
 from evidently.future.metrics import MAE
 from evidently.future.metrics import MAPE
@@ -62,7 +61,11 @@ class RegressionQuality(MetricContainer):
             AbsMaxError(tests=self._abs_max_error_tests),
         ]
 
-    def render(self, context: Context, results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         widgets = context.get_legacy_metric(
             RegressionQualityMetric(),
             _gen_regression_input_data,
@@ -82,7 +85,7 @@ class RegressionQuality(MetricContainer):
                 RegressionErrorDistribution(),
                 _gen_regression_input_data,
             )[1]
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(widgets, metric)
         return widgets
 
@@ -105,13 +108,17 @@ class RegressionDummyQuality(MetricContainer):
             DummyRMSE(tests=self._rmse_tests),
         ]
 
-    def render(self, context: Context, results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         widgets = context.get_legacy_metric(
             RegressionDummyMetric(),
             _gen_regression_input_data,
         )[1]
 
-        for metric in self.metrics(context):
+        for metric in self.list_metrics():
             link_metric(widgets, metric)
         return widgets
 
@@ -154,11 +161,15 @@ class RegressionPreset(MetricContainer):
             R2Score(tests=self._r2score_tests),
         ]
 
-    def render(self, context: "Context", results: Dict[MetricId, MetricResult]) -> List[BaseWidgetInfo]:
+    def render(
+        self,
+        context: "Context",
+        child_widgets: Optional[List[Tuple[Optional[MetricId], List[BaseWidgetInfo]]]] = None,
+    ) -> List[BaseWidgetInfo]:
         if self._quality is None:
             raise ValueError("No _quality set in preset, something went wrong.")
         return (
-            self._quality.render(context, results)
+            self._quality.render(context)
             + context.get_metric_result(
                 MAPE(mean_tests=self._mape_tests.mean, std_tests=self._mape_tests.std),
             ).widget

--- a/src/evidently/future/report.py
+++ b/src/evidently/future/report.py
@@ -275,8 +275,8 @@ class Snapshot:
         snapshot_items: List[SnapshotItem] = []
         for item in items:
             if isinstance(item, MetricContainer):
-                self._run_items(item.metrics(self.context), metric_results)
-                widget = item.render(self.context, results=metric_results)
+                container_items, container_widgets = self._run_items(item.metrics(self.context), metric_results)
+                widget = item.render(self.context, [(v.metric_id, v.widgets) for v in container_items])
                 widgets.extend(widget)
                 snapshot_items.append(SnapshotItem(None, widget))
             else:


### PR DESCRIPTION
In some cases if you use container as part of generator or container it will use render of underlying metrics and not container itself.

This fix adds the way to work with renders of underlying container directly.