### PR TITLE
Fix error when pass pd.DataFrame to reference_data.

### DIFF
--- a/src/evidently/future/report.py
+++ b/src/evidently/future/report.py
@@ -408,7 +408,7 @@ class Report:
     ) -> Snapshot:
         self._timestamp = timestamp or datetime.now()
         current_dataset = Dataset.from_any(current_data)
-        reference_dataset = Dataset.from_any(reference_data) if reference_data else None
+        reference_dataset = Dataset.from_any(reference_data) if reference_data is not None else None
         snapshot = Snapshot(self)
         snapshot.run(current_dataset, reference_dataset)
         return snapshot

--- a/tests/future/report/test_report.py
+++ b/tests/future/report/test_report.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from evidently.future.datasets import Dataset
+from evidently.future.metrics import MinValue
+from evidently.future.report import Report
+
+
+@pytest.mark.parametrize(
+    "current,reference",
+    [
+        (Dataset.from_pandas(pd.DataFrame(data={"a": [1, 2, 3]})), None),
+        (
+            Dataset.from_pandas(pd.DataFrame(data={"a": [1, 2, 3]})),
+            Dataset.from_pandas(pd.DataFrame(data={"a": [1, 2, 3]})),
+        ),
+        (pd.DataFrame(data={"a": [1, 2, 3]}), None),
+        (pd.DataFrame(data={"a": [1, 2, 3]}), pd.DataFrame(data={"a": [1, 2, 3]})),
+        (Dataset.from_pandas(pd.DataFrame(data={"a": [1, 2, 3]})), pd.DataFrame(data={"a": [1, 2, 3]})),
+        (pd.DataFrame(data={"a": [1, 2, 3]}), Dataset.from_pandas(pd.DataFrame(data={"a": [1, 2, 3]}))),
+    ],
+)
+def test_report_run(current, reference):
+    report = Report([MinValue(column="a")])
+
+    snapshot = report.run(current_data=current, reference_data=reference)
+    assert snapshot is not None


### PR DESCRIPTION
If pass pd.DataFrame to reference_data in Report.run() ends up with error: 
```
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```