### PR TITLE
Add support for smart_union in all metrics config.

### DIFF
--- a/src/evidently/future/metric_types.py
+++ b/src/evidently/future/metric_types.py
@@ -729,6 +729,7 @@ class Metric(AutoAliasMixin, EvidentlyBaseModel, Generic[TCalculation]):
 
     class Config:
         is_base_type = True
+        smart_union = True
 
     __calculation_type__: ClassVar[Type[TCalculation]]
 

--- a/tests/future/metrics/test_in_range_metric.py
+++ b/tests/future/metrics/test_in_range_metric.py
@@ -1,0 +1,7 @@
+from evidently.future.metrics import InRangeValueCount
+
+
+def test_in_range_metric():
+    metric = InRangeValueCount(column="a", left=0.5, right=1)
+    assert metric.left == 0.5
+    assert metric.right == 1

--- a/tests/future/metrics/test_out_range_metric.py
+++ b/tests/future/metrics/test_out_range_metric.py
@@ -1,0 +1,7 @@
+from evidently.future.metrics import OutRangeValueCount
+
+
+def test_out_range_metric():
+    metric = OutRangeValueCount(column="a", left=0.5, right=1)
+    assert metric.left == 0.5
+    assert metric.right == 1


### PR DESCRIPTION
If you pass float value in InRange / OutRange as left / right bound it would be rounded to int due to Union behavior in Pydantic.

Add `smart_union` option for all metric config classes so it would correctly coerce types.