### PR TITLE
issue #1400

### DIFF
--- a/src/evidently/calculations/stattests/psi.py
+++ b/src/evidently/calculations/stattests/psi.py
@@ -48,7 +48,7 @@ def _psi(
         psi_value: calculated PSI
         test_result: whether the drift is detected
     """
-    reference_percents, current_percents = get_binned_data(reference_data, current_data, feature_type, n_bins)
+    reference_percents, current_percents = get_binned_data(reference_data, current_data, feature_type, n=n_bins)
 
     psi_values = (reference_percents - current_percents) * np.log(reference_percents / current_percents)
     psi_value = np.sum(psi_values)
@@ -64,3 +64,5 @@ psi_stat_test = StatTest(
 )
 
 register_stattest(psi_stat_test, _psi)
+
+

--- a/src/evidently/calculations/stattests/utils.py
+++ b/src/evidently/calculations/stattests/utils.py
@@ -27,7 +27,7 @@ def get_binned_data(
     n_vals = reference_data.nunique()
 
     if feature_type == ColumnType.Numerical and n_vals > 20:
-        bins = np.histogram_bin_edges(pd.concat([reference_data, current_data], axis=0).values, bins="sturges")
+        bins = np.histogram_bin_edges(pd.concat([reference_data, current_data], axis=0).values, bins=n)
         reference_percents = np.histogram(reference_data, bins)[0] / len(reference_data)
         current_percents = np.histogram(current_data, bins)[0] / len(current_data)
 


### PR DESCRIPTION
docs: Clarify n_bins parameter usage in PSI calculation. This address issue #1400 and shows that n_bins is already correctly implemented and used to determine the number of bins in histogram calculation.