### PR TITLE
Support token from env variables.

### DIFF
--- a/src/evidently/ui/workspace/cloud.py
+++ b/src/evidently/ui/workspace/cloud.py
@@ -221,9 +221,17 @@ class CloudWorkspace(WorkspaceView):
 
     def __init__(
         self,
-        token: str,
+        token: Optional[str] = None,
         url: str = None,
     ):
+        if token is None:
+            import os
+
+            token = os.environ.get("EVIDENTLY_API_KEY", default=None)
+        if token is None:
+            raise ValueError(
+                "To use CloudWorkspace you must provide a token through argument or env variable EVIDENTLY_API_KEY"
+            )
         self.token = token
         self.url = url if url is not None else self.URL
 


### PR DESCRIPTION
Support providing API KEY for CloudWorkspace using environment variable EVIDENTLY_API_KEY.

If API_KEY isn't provided using argument, then check env variable EVIDENTLY_API_KEY, and only after that throw exception.