### PR TITLE
add include_tests flag for presets

### DIFF
--- a/src/evidently/future/container.py
+++ b/src/evidently/future/container.py
@@ -19,6 +19,9 @@ MetricOrContainer = Union[Metric, "MetricContainer"]
 
 
 class MetricContainer(abc.ABC):
+    def __init__(self, include_tests: bool = True):
+        self.include_tests = include_tests
+
     @abc.abstractmethod
     def generate_metrics(self, context: "Context") -> Sequence[MetricOrContainer]:
         raise NotImplementedError()
@@ -50,7 +53,15 @@ class MetricContainer(abc.ABC):
             else:
                 raise ValueError(f"invalid metric type {type(item)}")
 
+    def _get_tests(self, tests):
+        if tests is not None:
+            return tests
+        if self.include_tests:
+            return None
+        return []
+
 
 class ColumnMetricContainer(MetricContainer, abc.ABC):
-    def __init__(self, column: str):
+    def __init__(self, column: str, include_tests: bool = True):
+        super().__init__(include_tests=include_tests)
         self._column = column

--- a/src/evidently/future/generators/column.py
+++ b/src/evidently/future/generators/column.py
@@ -33,6 +33,7 @@ class ColumnMetricGenerator(MetricContainer):
         self.columns = columns
         self.column_types = column_types
         self.metric_kwargs = metric_kwargs or {}
+        super().__init__(include_tests=True)
 
     def _instantiate_metric(self, column: str) -> MetricOrContainer:
         return self.metric_type(column=column, **self.metric_kwargs)

--- a/src/evidently/future/metrics/group_by.py
+++ b/src/evidently/future/metrics/group_by.py
@@ -49,6 +49,7 @@ class GroupBy(MetricContainer):
     def __init__(self, metric: Metric, column_name: str):
         self._column_name = column_name
         self._metric = metric
+        super().__init__(True)
 
     def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         labels = context.column(self._column_name).labels()

--- a/src/evidently/future/presets/drift.py
+++ b/src/evidently/future/presets/drift.py
@@ -53,6 +53,7 @@ class DataDriftPreset(MetricContainer):
         self.embeddings_drift_method = embeddings_drift_method
         self.embeddings = embeddings
         self.columns = columns
+        super().__init__(include_tests=True)
 
     def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         types = [ColumnType.Numerical, ColumnType.Categorical, ColumnType.Text]

--- a/src/evidently/future/presets/regression.py
+++ b/src/evidently/future/presets/regression.py
@@ -40,6 +40,7 @@ class RegressionQuality(MetricContainer):
         mae_tests: Optional[MeanStdMetricTests] = None,
         r2score_tests: SingleValueMetricTests = None,
         abs_max_error_tests: SingleValueMetricTests = None,
+        include_tests: bool = True,
     ):
         self._pred_actual_plot = pred_actual_plot
         self._error_plot = error_plot
@@ -50,15 +51,19 @@ class RegressionQuality(MetricContainer):
         self._mae_tests = mae_tests or MeanStdMetricTests()
         self._r2score_tests = r2score_tests
         self._abs_max_error_tests = abs_max_error_tests
+        super().__init__(include_tests=include_tests)
 
     def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         return [
-            MeanError(mean_tests=self._mean_error_tests.mean, std_tests=self._mean_error_tests.std),
-            MAPE(mean_tests=self._mape_tests.mean, std_tests=self._mape_tests.std),
-            RMSE(tests=self._rmse_tests),
-            MAE(mean_tests=self._mae_tests.mean, std_tests=self._mae_tests.std),
-            R2Score(tests=self._r2score_tests),
-            AbsMaxError(tests=self._abs_max_error_tests),
+            MeanError(
+                mean_tests=self._get_tests(self._mean_error_tests.mean),
+                std_tests=self._get_tests(self._mean_error_tests.std),
+            ),
+            MAPE(mean_tests=self._get_tests(self._mape_tests.mean), std_tests=self._get_tests(self._mape_tests.std)),
+            RMSE(tests=self._get_tests(self._rmse_tests)),
+            MAE(mean_tests=self._get_tests(self._mae_tests.mean), std_tests=self._get_tests(self._mae_tests.std)),
+            R2Score(tests=self._get_tests(self._r2score_tests)),
+            AbsMaxError(tests=self._get_tests(self._abs_max_error_tests)),
         ]
 
     def render(
@@ -96,16 +101,18 @@ class RegressionDummyQuality(MetricContainer):
         mae_tests: SingleValueMetricTests = None,
         mape_tests: SingleValueMetricTests = None,
         rmse_tests: SingleValueMetricTests = None,
+        include_tests: bool = True,
     ):
         self._mae_tests = mae_tests
         self._mape_tests = mape_tests
         self._rmse_tests = rmse_tests
+        super().__init__(include_tests=include_tests)
 
     def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         return [
-            DummyMAE(tests=self._mae_tests),
-            DummyMAPE(tests=self._mape_tests),
-            DummyRMSE(tests=self._rmse_tests),
+            DummyMAE(tests=self._get_tests(self._mae_tests)),
+            DummyMAPE(tests=self._get_tests(self._mape_tests)),
+            DummyRMSE(tests=self._get_tests(self._rmse_tests)),
         ]
 
     def render(
@@ -134,6 +141,7 @@ class RegressionPreset(MetricContainer):
         mae_tests: Optional[MeanStdMetricTests] = None,
         r2score_tests: SingleValueMetricTests = None,
         abs_max_error_tests: SingleValueMetricTests = None,
+        include_tests: bool = True,
     ):
         self._quality = None
         self._mean_error_tests = mean_error_tests or MeanStdMetricTests()
@@ -142,6 +150,7 @@ class RegressionPreset(MetricContainer):
         self._mae_tests = mae_tests or MeanStdMetricTests()
         self._r2score_tests = r2score_tests
         self._abs_max_error_tests = abs_max_error_tests
+        super().__init__(include_tests=include_tests)
 
     def generate_metrics(self, context: Context) -> Sequence[MetricOrContainer]:
         self._quality = RegressionQuality(
@@ -154,11 +163,12 @@ class RegressionPreset(MetricContainer):
             self._mae_tests,
             self._r2score_tests,
             self._abs_max_error_tests,
+            include_tests=self.include_tests,
         )
         return self._quality.metrics(context) + [
-            MAPE(mean_tests=self._mape_tests.mean, std_tests=self._mape_tests.std),
-            AbsMaxError(tests=self._abs_max_error_tests),
-            R2Score(tests=self._r2score_tests),
+            MAPE(mean_tests=self._get_tests(self._mape_tests.mean), std_tests=self._get_tests(self._mape_tests.std)),
+            AbsMaxError(tests=self._get_tests(self._abs_max_error_tests)),
+            R2Score(tests=self._get_tests(self._r2score_tests)),
         ]
 
     def render(

--- a/tests/future/presets/regression.py
+++ b/tests/future/presets/regression.py
@@ -23,6 +23,9 @@ from evidently.future.tests import lt
         (RegressionQuality(rmse_tests=[lt(0.1)]), 1),
         (RegressionQuality(r2score_tests=[lt(0.1)]), 1),
         (RegressionQuality(abs_max_error_tests=[lt(0.1)]), 1),
+        (RegressionQuality(abs_max_error_tests=[lt(0.1)], include_tests=False), 1),
+        (RegressionQuality(abs_max_error_tests=[lt(0.1)], include_tests=True), 1),
+        (RegressionQuality(include_tests=True), 0),
     ],
 )
 def test_regression_quality_preset_tests(preset, expected_tests):
@@ -32,5 +35,26 @@ def test_regression_quality_preset_tests(preset, expected_tests):
         data_definition=DataDefinition(regression=[Regression()]),
     )
     snapshot = report.run(dataset)
+    snapshot_data = snapshot.dict()
+    assert len(snapshot_data["tests"]) == expected_tests
+
+
+@pytest.mark.parametrize(
+    "preset,expected_tests",
+    [
+        (RegressionQuality(), 6),
+        (RegressionQuality(abs_max_error_tests=[lt(0.1)], include_tests=False), 1),
+        (RegressionQuality(abs_max_error_tests=[], include_tests=True), 5),
+        (RegressionQuality(include_tests=True), 6),
+        (RegressionQuality(include_tests=False), 0),
+    ],
+)
+def test_test_regression_quality_preset_tests_with_reference(preset, expected_tests):
+    report = Report([preset], include_tests=True)
+    dataset = Dataset.from_pandas(
+        pd.DataFrame(data=dict(target=[1, 2, 3, 4, 5], prediction=[0, 1, 2, 3, 4])),
+        data_definition=DataDefinition(regression=[Regression()]),
+    )
+    snapshot = report.run(dataset, reference_data=dataset)
     snapshot_data = snapshot.dict()
     assert len(snapshot_data["tests"]) == expected_tests


### PR DESCRIPTION
### PR Description

**Enhancement: Add Configuration Option for Test Inclusion in Metric Containers**

This PR introduces an `include_tests` parameter in various metric container classes within the Evidently library. By default, this parameter is set to `True`, allowing users to specify whether metric tests should be included in the generated metrics. This flexibility helps improve the customization of metrics based on user requirements.

### Summary of Changes
1. Added `include_tests` parameter to `MetricContainer` and its subclasses.
2. Updated existing metric generation methods to conditionally include tests based on the `include_tests` parameter.

### Code Snippets

**Example 1: Basic Metric Generation with Tests Included**
```python
# Using default behavior (include_tests=True)
metric_container = ColumnMetricContainer(column='age')
metrics = metric_container.generate_metrics(context)
```

**Example 2: Metric Generation without Tests**
```python
# Exclude tests in metrics generation
metric_container_without_tests = ColumnMetricContainer(column='age', include_tests=False)
metrics_no_tests = metric_container_without_tests.generate_metrics(context)
```

**Example 3: Classification Quality with Custom Test Inclusion**
```python
# Include tests when creating the classification quality metric
classification_quality = ClassificationQuality(
    accuracy_tests=accuracy_tests,
    precision_tests=precision_tests,
    include_tests=True
)

metrics = classification_quality.generate_metrics(context)
```

This enhancement grants users greater control over their metrics, allowing them to tailor the output based on their analysis needs.