### PR TITLE
Remove scipy deprecation warning

### DIFF
--- a/src/evidently/utils/visualizations.py
+++ b/src/evidently/utils/visualizations.py
@@ -12,7 +12,7 @@ from pandas.api.types import is_datetime64_any_dtype
 from plotly import graph_objs as go
 from plotly.subplots import make_subplots
 from scipy import stats
-from scipy.linalg.basic import LinAlgError
+from scipy.linalg import LinAlgError
 
 from evidently.metric_results import ContourData
 from evidently.metric_results import Distribution


### PR DESCRIPTION
In our organisation we want to start using Evidently. However, we have strict tests on Deprecation warnings not being allowed. Currently, there is a Deprecation warning within the Evidently package around Scipy. This PR solves that Deprecation warning. Discussed in this [issue](https://github.com/evidentlyai/evidently/issues/1534)