### PR TITLE
fix nan in unique values

### DIFF
--- a/src/evidently/future/metric_types.py
+++ b/src/evidently/future/metric_types.py
@@ -900,6 +900,7 @@ class ByLabelCountBoundTest(BoundTest[ByLabelCountValue]):
 
 
 class ByLabelCountMetric(Metric):
+    replace_nan: Optional[Label] = None
     tests: Optional[Dict[Label, List[MetricTest]]] = None
     share_tests: Optional[Dict[Label, List[MetricTest]]] = None
 

--- a/src/evidently/future/metrics/column_statistics.py
+++ b/src/evidently/future/metrics/column_statistics.py
@@ -7,8 +7,6 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
-import numpy as np
-
 from evidently.calculations.data_drift import ColumnDataDriftMetrics
 from evidently.calculations.data_drift import get_one_column_drift
 from evidently.calculations.stattests import PossibleStatTestType
@@ -687,7 +685,5 @@ class UniqueValueCountCalculation(ByLabelCountCalculation[UniqueValueCount]):
         total = len(df)
 
         res = value_counts.to_dict()
-        if np.nan in res:
-            res[None] = res.pop(np.nan)
         result = self.result(res, {k: v / total for k, v in res.items()})  # type: ignore[arg-type]
         return result

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -218,14 +218,15 @@ class ValueStats(ColumnMetricContainer):
 
     def _render_categorical_binary(self, context: "Context") -> List[BaseWidgetInfo]:
         unique_value_count = self._categorical_unique_value_count_metric()
-        result: ByLabelCountValue = context.get_metric_result(
+        result: MetricResult = context.get_metric_result(
             unique_value_count,
         )
-        ref_result: Optional[ByLabelCountValue] = None
+        assert isinstance(result, ByLabelCountValue)
+
+        ref_result: Optional[MetricResult] = None
         if context.has_reference:
-            ref = context.get_reference_metric_result(unique_value_count.metric_id)
-            assert isinstance(ref, ByLabelCountValue)
-            ref_result = ref
+            ref_result = context.get_reference_metric_result(unique_value_count.metric_id)
+            assert isinstance(ref_result, ByLabelCountValue)
 
         metrics_widget = result.get_widgets()[0]
         return [

--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -218,14 +218,12 @@ class ValueStats(ColumnMetricContainer):
 
     def _render_categorical_binary(self, context: "Context") -> List[BaseWidgetInfo]:
         unique_value_count = self._categorical_unique_value_count_metric()
-        result: MetricResult = context.get_metric_result(
-            unique_value_count,
-        )
+        result: ByLabelCountValue = context.get_metric_result(unique_value_count)  # type: ignore[assignment]
         assert isinstance(result, ByLabelCountValue)
 
-        ref_result: Optional[MetricResult] = None
+        ref_result: Optional[ByLabelCountValue] = None
         if context.has_reference:
-            ref_result = context.get_reference_metric_result(unique_value_count.metric_id)
+            ref_result = context.get_reference_metric_result(unique_value_count.metric_id)  # type: ignore[assignment]
             assert isinstance(ref_result, ByLabelCountValue)
 
         metrics_widget = result.get_widgets()[0]

--- a/src/evidently/future/report.py
+++ b/src/evidently/future/report.py
@@ -128,7 +128,7 @@ class Context:
         self._current_graph_level = prev_level
         return typing.cast(TResultType, self._metrics[calc.id])
 
-    def get_metric_result(self, metric: Union[MetricId, Metric, MetricCalculationBase[TResultType]]) -> TResultType:
+    def get_metric_result(self, metric: Union[MetricId, Metric, MetricCalculationBase[TResultType]]) -> MetricResult:
         if isinstance(metric, MetricId):
             return self._metrics[metric]
         if isinstance(metric, Metric):

--- a/src/evidently/future/report.py
+++ b/src/evidently/future/report.py
@@ -60,6 +60,8 @@ class ContextColumnData:
         self._labels = None
 
     def labels(self):
+        if self.column_type != ColumnType.Categorical:
+            raise AttributeError("labels() is not supported for non-categorical columns")
         if self._labels is None:
             self._labels = list(self._column.data.unique())
         return self._labels
@@ -126,7 +128,7 @@ class Context:
         self._current_graph_level = prev_level
         return typing.cast(TResultType, self._metrics[calc.id])
 
-    def get_metric_result(self, metric: Union[MetricId, Metric, MetricCalculationBase[TResultType]]) -> MetricResult:
+    def get_metric_result(self, metric: Union[MetricId, Metric, MetricCalculationBase[TResultType]]) -> TResultType:
         if isinstance(metric, MetricId):
             return self._metrics[metric]
         if isinstance(metric, Metric):

--- a/tests/future/presets/dataset_stats.py
+++ b/tests/future/presets/dataset_stats.py
@@ -1,26 +1,52 @@
+import numpy as np
 import pandas as pd
 import pytest
 
 from evidently.future.datasets import DataDefinition
 from evidently.future.datasets import Dataset
+from evidently.future.metric_types import ByLabelCountValue
 from evidently.future.presets import ValueStats
 from evidently.future.report import Report
 
 
 @pytest.mark.parametrize(
-    "dataset,column,expected_metric_count",
+    "dataset,preset,expected_metric_count,unique_result",
     [
         (
             Dataset.from_pandas(
                 pd.DataFrame(data=dict(column=[1, 1, 1, 1, 0])),
                 data_definition=DataDefinition(categorical_columns=["column"]),
             ),
-            "column",
+            ValueStats(column="column"),
             3,
+            None,
+        ),
+        (
+            Dataset.from_pandas(
+                pd.DataFrame(data=dict(column=["a", "b", np.nan])),
+                data_definition=DataDefinition(categorical_columns=["column"]),
+            ),
+            ValueStats(column="column"),
+            3,
+            {"a": 1, "b": 1},
+        ),
+        (
+            Dataset.from_pandas(
+                pd.DataFrame(data=dict(column=["a", "b", np.nan])),
+                data_definition=DataDefinition(categorical_columns=["column"]),
+            ),
+            ValueStats(column="column", replace_nan="aaaa"),
+            3,
+            {"a": 1, "b": 1, "aaaa": 1},
         ),
     ],
 )
-def test_value_stats(dataset, column, expected_metric_count):
-    report = Report([ValueStats(column=column)])
+def test_value_stats(dataset, preset, expected_metric_count, unique_result):
+    report = Report([preset])
     snapshot = report.run(dataset, None)
     assert len(snapshot.dict()["metrics"]) == expected_metric_count
+    if unique_result is not None:
+        ur = snapshot._context.get_metric_result(preset._categorical_unique_value_count_metric())
+        assert isinstance(ur, ByLabelCountValue)
+        ur_counts = {k: v.value for k, v in ur.counts.items()}
+        assert ur_counts == unique_result


### PR DESCRIPTION
### Pull Request Description

**Overview**: This PR introduces a new feature to the `ValueStats` class, allowing for the handling of `NaN` values in categorical data through a new parameter `replace_nan`. This enhancement enables users to specify a label that will replace `NaN` values during calculations, thereby improving the accuracy and usability of unique value counts in datasets.

#### Changes:
- Added `replace_nan` parameter to `ByLabelCountMetric` and `ValueStats` classes.
- Updated `UniqueValueCountCalculation` to utilize the `replace_nan` parameter for counting unique values.
- Modified reports to reflect the new behavior in categorical metrics.

#### Example Use Cases:

1. **Basic Unique Value Count**:
   ```python
   dataset = Dataset.from_pandas(
       pd.DataFrame(data=dict(column=["a", "b", np.nan])),
       data_definition=DataDefinition(categorical_columns=["column"]),
   )
   value_stats = ValueStats(column="column")
   report = Report([value_stats])
   snapshot = report.run(dataset, None)
   # Expected unique counts: {'a': 1, 'b': 1}
   ```

2. **Replacing `NaN` with a Custom Label**:
   ```python
   dataset = Dataset.from_pandas(
       pd.DataFrame(data=dict(column=["a", "b", np.nan])),
       data_definition=DataDefinition(categorical_columns=["column"]),
   )
   value_stats = ValueStats(column="column", replace_nan="unknown")
   report = Report([value_stats])
   snapshot = report.run(dataset, None)
   # Expected unique counts: {'a': 1, 'b': 1, 'unknown': 1}
   ```

3. **Multiple Categorical Values with Replacement**:
   ```python
   dataset = Dataset.from_pandas(
       pd.DataFrame(data=dict(column=["a", "b", np.nan, np.nan, "c"])),
       data_definition=DataDefinition(categorical_columns=["column"]),
   )
   value_stats = ValueStats(column="column", replace_nan="N/A")
   report = Report([value_stats])
   snapshot = report.run(dataset, None)
   # Expected unique counts: {'a': 1, 'b': 1, 'c': 1, 'N/A': 2}
   ```

This feature provides greater flexibility in handling datasets with `NaN` values, enhancing the utility of the `ValueStats` metrics generation process.