### PR TITLE
add share to missing count metric

### DIFF
--- a/src/evidently/future/presets/dataset_stats.py
+++ b/src/evidently/future/presets/dataset_stats.py
@@ -324,6 +324,7 @@ class DatasetStats(MetricContainer):
     empty_column_count_tests: SingleValueMetricTests = None
     constant_columns_count_tests: SingleValueMetricTests = None
     dataset_missing_value_count_tests: SingleValueMetricTests = None
+    dataset_missing_value_share_tests: SingleValueMetricTests = None
 
     def __init__(
         self,
@@ -337,6 +338,7 @@ class DatasetStats(MetricContainer):
         empty_column_count_tests: SingleValueMetricTests = None,
         constant_columns_count_tests: SingleValueMetricTests = None,
         dataset_missing_value_count_tests: SingleValueMetricTests = None,
+        dataset_missing_value_share_tests: SingleValueMetricTests = None,
         include_tests: bool = True,
     ):
         self.duplicated_row_count_tests = duplicated_row_count_tests
@@ -347,6 +349,7 @@ class DatasetStats(MetricContainer):
         self.empty_column_count_tests = empty_column_count_tests
         self.constant_columns_count_tests = constant_columns_count_tests
         self.dataset_missing_value_count_tests = dataset_missing_value_count_tests
+        self.dataset_missing_value_share_tests = dataset_missing_value_share_tests
         self.column_count_tests = column_count_tests
         self.row_count_tests = row_count_tests
         super().__init__(include_tests=include_tests)
@@ -366,7 +369,10 @@ class DatasetStats(MetricContainer):
             EmptyRowsCount(tests=self._get_tests(self.empty_row_count_tests)),
             EmptyColumnsCount(tests=self._get_tests(self.empty_column_count_tests)),
             ConstantColumnsCount(tests=self._get_tests(self.constant_columns_count_tests)),
-            DatasetMissingValueCount(tests=self._get_tests(self.dataset_missing_value_count_tests)),
+            DatasetMissingValueCount(
+                tests=self._get_tests(self.dataset_missing_value_count_tests),
+                share_tests=self._get_tests(self.dataset_missing_value_share_tests),
+            ),
         ]
 
     def render(

--- a/tests/future/metrics/test_missing_count.py
+++ b/tests/future/metrics/test_missing_count.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from evidently.future.datasets import Dataset
+from evidently.future.metric_types import CountValue
+from evidently.future.metrics import DatasetMissingValueCount
+from evidently.future.report import Report
+
+
+@pytest.mark.parametrize(
+    "data,metric,result",
+    [(pd.DataFrame({"a": [1, 2, np.nan, np.nan]}), DatasetMissingValueCount(), {"count": 2, "share": 0.5})],
+)
+def test_missing_count(data, metric, result):
+    dataset = Dataset.from_pandas(data)
+    report = Report([metric])
+    run = report.run(dataset, None)
+    res = run._context.get_metric_result(metric)
+    assert isinstance(res, CountValue)
+    assert res.count.value == result["count"]
+    assert res.share.value == result["share"]


### PR DESCRIPTION
### PR Description

This PR introduces enhancements to the `dataset_statistics.py` module, including the addition of new calculation classes and improved handling of missing values. The primary changes involve the refactoring of existing classes to leverage a new base mixin for better organization and maintainability.

#### Key Changes:
- Added `DatasetSummarySingleValueCalculation` and `DatasetSummaryCountValueCalculation` classes.
- Updated `DatasetMissingValueCount` to support both count and share calculations.
- Refactored existing calculation classes to use the new single value calculation class.

#### New Example Usages:

1. **Count of Missing Values**
   ```python
   import pandas as pd
   from evidently.future.datasets import Dataset
   from evidently.future.metrics import DatasetMissingValueCount
   from evidently.future.report import Report

   data = pd.DataFrame({"feature_1": [1, 2, None, 4]})
   dataset = Dataset.from_pandas(data)
   metric = DatasetMissingValueCount()
   report = Report([metric])
   result = report.run(dataset, None)
   count_result = result._context.get_metric_result(metric)
   print(count_result.count.value)  # Output: 1 (number of missing values)
   print(count_result.share.value)  # Output: 0.25 (share of missing values)
   ```

This PR strengthens the functionality around missing value metrics and creates a cleaner, more extendable foundation for future metric calculations.