### PR TITLE
POC descriptor tests

### DIFF
--- a/src/evidently/core/tests.py
+++ b/src/evidently/core/tests.py
@@ -1,0 +1,30 @@
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+from typing import Callable
+
+if TYPE_CHECKING:
+    from .datasets import DescriptorTest
+    from .metric_types import MetricTest
+
+
+class GenericTest:
+    @abstractmethod
+    def for_metric(self) -> "MetricTest":
+        raise NotImplementedError
+
+    @abstractmethod
+    def for_descriptor(self) -> "DescriptorTest":
+        raise NotImplementedError
+
+
+class FactoryGenericTest(GenericTest):
+    def __init__(self, metric: Callable[[], "MetricTest"], descriptor: Callable[[], "DescriptorTest"]):
+        self.metric = metric
+
+        self.descriptor = descriptor
+
+    def for_metric(self) -> "MetricTest":
+        return self.metric()
+
+    def for_descriptor(self) -> "DescriptorTest":
+        return self.descriptor()

--- a/src/evidently/tests/descriptors.py
+++ b/src/evidently/tests/descriptors.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+import pandas as pd
+
+from evidently.core.datasets import DescriptorTest
+
+
+class EqualsDescriptorTest(DescriptorTest):
+    expected: Any
+
+    def apply(self, row: pd.Series) -> bool:
+        return any(r == self.expected for r in row)

--- a/src/evidently/tests/numerical_tests.py
+++ b/src/evidently/tests/numerical_tests.py
@@ -12,7 +12,10 @@ from evidently.core.metric_types import SingleValueTest
 from evidently.core.metric_types import TestStatus
 from evidently.core.metric_types import Value
 from evidently.core.report import Context
+from evidently.core.tests import FactoryGenericTest
+from evidently.core.tests import GenericTest
 from evidently.legacy.utils.types import ApproxValue
+from evidently.tests.descriptors import EqualsDescriptorTest
 from evidently.tests.reference import Reference
 
 ThresholdType = Union[float, int, ApproxValue, Reference]
@@ -145,8 +148,11 @@ class EqualMetricTest(EqualMetricTestBase):
         return func
 
 
-def eq(expected: ThresholdType, is_critical: bool = True) -> MetricTest:
-    return EqualMetricTest(expected=expected, is_critical=is_critical)
+def eq(expected: ThresholdType, is_critical: bool = True) -> GenericTest:
+    return FactoryGenericTest(
+        lambda: EqualMetricTest(expected=expected, is_critical=is_critical),
+        lambda: EqualsDescriptorTest(expected=expected),
+    )
 
 
 class NotEqualMetricTest(EqualMetricTestBase):


### PR DESCRIPTION
```python
from typing import Union, Dict

import pandas as pd

from evidently import Dataset, ColumnType
from evidently.core.datasets import Descriptor, DatasetColumn
from evidently.legacy.base_metric import DisplayName
from evidently.legacy.options.base import Options
from evidently.tests import eq


class Add1(Descriptor):
    column: str

    def generate_data(self, dataset: "Dataset", options: Options) -> Union[
        DatasetColumn, Dict[DisplayName, DatasetColumn]]:
        col = dataset.column(self.column)
        return DatasetColumn(type=ColumnType.Numerical, data=col.data + 1)


class Add12(Descriptor):
    column: str

    def generate_data(self, dataset: "Dataset", options: Options) -> Union[
        DatasetColumn, Dict[DisplayName, DatasetColumn]]:
        col = dataset.column(self.column)
        return {
            "add 1": DatasetColumn(type=ColumnType.Numerical, data=col.data + 1),
            "add 2": DatasetColumn(type=ColumnType.Numerical, data=col.data + 2),
        }


def main():
    data = {"col": [1, 2, 3]}
    dataset = Dataset.from_pandas(
        pd.DataFrame(data),
        descriptors=[
            Add1(column="col", alias="col_plus_1", tests=[eq(2)]),
            Add12(column="col", alias="col_plus_12", tests=[eq(3)]),
            # aggregated score/test:
            # CaseEval(success=True, rate=True, score=True, all=True, any=True,
            #          score_weights={"summary_negativity": 0.9, "summary_length": 0.1},
            #          alias="case_eval"),
        ],
    )
    df = dataset.as_dataframe()
    for col in df.columns:
        print(col)
        print(df[col].tolist())
        print()


if __name__ == '__main__':
    main()
```