### PR TITLE
downsample scatter for roc auc and pr curves

### DIFF
--- a/src/evidently/legacy/metrics/classification_performance/pr_curve_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/pr_curve_metric.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 from sklearn import metrics
 
@@ -20,6 +21,8 @@ from evidently.legacy.renderers.html_widgets import get_pr_rec_plot_data
 from evidently.legacy.renderers.html_widgets import header_text
 from evidently.legacy.renderers.html_widgets import widget_tabs
 from evidently.legacy.utils.data_operations import process_columns
+
+PR_CURVE_MAX_POINTS = 1000
 
 
 class ClassificationPRCurveResults(MetricResult):
@@ -64,6 +67,11 @@ class ClassificationPRCurve(Metric[ClassificationPRCurveResults]):
             binaraized_target = pd.DataFrame(binaraized_target[:, 0])
             binaraized_target.columns = ["target"]
             pr, rcl, thrs = metrics.precision_recall_curve(binaraized_target, prediction.prediction_probas.iloc[:, 0])
+            if len(pr) > PR_CURVE_MAX_POINTS:
+                idx = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
+                pr = pr[idx + 1]
+                rcl = rcl[idx + 1]
+                thrs = thrs[idx]
             pr_curve[prediction.prediction_probas.columns[0]] = PRCurveData(
                 pr=pr.tolist(),
                 rcl=rcl.tolist(),
@@ -77,6 +85,11 @@ class ClassificationPRCurve(Metric[ClassificationPRCurveResults]):
                     binaraized_target[label],
                     prediction.prediction_probas[label],
                 )
+                if len(pr) > PR_CURVE_MAX_POINTS:
+                    idx = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
+                    pr = pr[idx + 1]
+                    rcl = rcl[idx + 1]
+                    thrs = thrs[idx]
 
                 pr_curve[label] = PRCurveData(
                     pr=pr.tolist(),

--- a/src/evidently/legacy/metrics/classification_performance/pr_curve_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/pr_curve_metric.py
@@ -68,7 +68,7 @@ class ClassificationPRCurve(Metric[ClassificationPRCurveResults]):
             binaraized_target.columns = ["target"]
             pr, rcl, thrs = metrics.precision_recall_curve(binaraized_target, prediction.prediction_probas.iloc[:, 0])
             if len(pr) > PR_CURVE_MAX_POINTS:
-                idx = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
+                idx: np.ndarray = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
                 pr = pr[idx + 1]
                 rcl = rcl[idx + 1]
                 thrs = thrs[idx]
@@ -86,7 +86,7 @@ class ClassificationPRCurve(Metric[ClassificationPRCurveResults]):
                     prediction.prediction_probas[label],
                 )
                 if len(pr) > PR_CURVE_MAX_POINTS:
-                    idx = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
+                    idx: np.ndarray = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
                     pr = pr[idx + 1]
                     rcl = rcl[idx + 1]
                     thrs = thrs[idx]

--- a/src/evidently/legacy/metrics/classification_performance/pr_curve_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/pr_curve_metric.py
@@ -63,12 +63,13 @@ class ClassificationPRCurve(Metric[ClassificationPRCurveResults]):
             raise ValueError("PR Curve can be calculated only on binary probabilistic predictions")
         binaraized_target = (target_data.to_numpy().reshape(-1, 1) == labels).astype(int)
         pr_curve: PRCurve = {}
+        idx: np.ndarray
         if len(labels) <= 2:
             binaraized_target = pd.DataFrame(binaraized_target[:, 0])
             binaraized_target.columns = ["target"]
             pr, rcl, thrs = metrics.precision_recall_curve(binaraized_target, prediction.prediction_probas.iloc[:, 0])
             if len(pr) > PR_CURVE_MAX_POINTS:
-                idx: np.ndarray = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
+                idx = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
                 pr = pr[idx + 1]
                 rcl = rcl[idx + 1]
                 thrs = thrs[idx]
@@ -86,7 +87,7 @@ class ClassificationPRCurve(Metric[ClassificationPRCurveResults]):
                     prediction.prediction_probas[label],
                 )
                 if len(pr) > PR_CURVE_MAX_POINTS:
-                    idx: np.ndarray = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
+                    idx = np.linspace(0, len(thrs) - 1, PR_CURVE_MAX_POINTS).astype(int)
                     pr = pr[idx + 1]
                     rcl = rcl[idx + 1]
                     thrs = thrs[idx]

--- a/src/evidently/legacy/metrics/classification_performance/roc_curve_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/roc_curve_metric.py
@@ -85,13 +85,14 @@ class ClassificationRocCurve(Metric[ClassificationRocCurveResults]):
             raise ValueError("Roc Curve can be calculated only on binary probabilistic predictions")
         binaraized_target = (target_data.to_numpy().reshape(-1, 1) == labels).astype(int)
         roc_curve: ROCCurve = {}
+        idx: np.ndarray
         if len(labels) <= 2:
             binaraized_target = pd.DataFrame(binaraized_target[:, 0])
             binaraized_target.columns = ["target"]
 
             fpr, tpr, thrs = metrics.roc_curve(binaraized_target, prediction.prediction_probas.iloc[:, 0])
             if len(fpr) > ROC_CURVE_MAX_POINTS:
-                idx: np.ndarray = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
+                idx = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
                 fpr = fpr[idx]
                 tpr = tpr[idx]
                 thrs = thrs[idx]
@@ -106,7 +107,7 @@ class ClassificationRocCurve(Metric[ClassificationRocCurveResults]):
                 mapped_label = tn.get(label, label)
                 fpr, tpr, thrs = metrics.roc_curve(binaraized_target[label], prediction.prediction_probas[label])
                 if len(fpr) > ROC_CURVE_MAX_POINTS:
-                    idx: np.ndarray = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
+                    idx = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
                     fpr = fpr[idx]
                     tpr = tpr[idx]
                     thrs = thrs[idx]

--- a/src/evidently/legacy/metrics/classification_performance/roc_curve_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/roc_curve_metric.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+import numpy as np
 import pandas as pd
 from sklearn import metrics
 
@@ -23,6 +24,8 @@ from evidently.legacy.renderers.html_widgets import get_roc_auc_tab_data
 from evidently.legacy.renderers.html_widgets import header_text
 from evidently.legacy.renderers.html_widgets import widget_tabs
 from evidently.legacy.utils.data_operations import process_columns
+
+ROC_CURVE_MAX_POINTS = 1000
 
 
 class ClassificationRocCurveResults(MetricResult):
@@ -87,6 +90,11 @@ class ClassificationRocCurve(Metric[ClassificationRocCurveResults]):
             binaraized_target.columns = ["target"]
 
             fpr, tpr, thrs = metrics.roc_curve(binaraized_target, prediction.prediction_probas.iloc[:, 0])
+            if len(fpr) > ROC_CURVE_MAX_POINTS:
+                idx = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
+                fpr = fpr[idx]
+                tpr = tpr[idx]
+                thrs = thrs[idx]
             roc_curve[prediction.prediction_probas.columns[0]] = ROCCurveData(
                 fpr=fpr.tolist(), tpr=tpr.tolist(), thrs=thrs.tolist()
             )
@@ -97,6 +105,11 @@ class ClassificationRocCurve(Metric[ClassificationRocCurveResults]):
             for label in labels:
                 mapped_label = tn.get(label, label)
                 fpr, tpr, thrs = metrics.roc_curve(binaraized_target[label], prediction.prediction_probas[label])
+                if len(fpr) > ROC_CURVE_MAX_POINTS:
+                    idx = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
+                    fpr = fpr[idx]
+                    tpr = tpr[idx]
+                    thrs = thrs[idx]
                 roc_curve[mapped_label] = ROCCurveData(fpr=fpr.tolist(), tpr=tpr.tolist(), thrs=thrs.tolist())
         return roc_curve
 

--- a/src/evidently/legacy/metrics/classification_performance/roc_curve_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/roc_curve_metric.py
@@ -91,7 +91,7 @@ class ClassificationRocCurve(Metric[ClassificationRocCurveResults]):
 
             fpr, tpr, thrs = metrics.roc_curve(binaraized_target, prediction.prediction_probas.iloc[:, 0])
             if len(fpr) > ROC_CURVE_MAX_POINTS:
-                idx = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
+                idx: np.ndarray = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
                 fpr = fpr[idx]
                 tpr = tpr[idx]
                 thrs = thrs[idx]
@@ -106,7 +106,7 @@ class ClassificationRocCurve(Metric[ClassificationRocCurveResults]):
                 mapped_label = tn.get(label, label)
                 fpr, tpr, thrs = metrics.roc_curve(binaraized_target[label], prediction.prediction_probas[label])
                 if len(fpr) > ROC_CURVE_MAX_POINTS:
-                    idx = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
+                    idx: np.ndarray = np.linspace(0, len(fpr) - 1, ROC_CURVE_MAX_POINTS).astype(int)
                     fpr = fpr[idx]
                     tpr = tpr[idx]
                     thrs = thrs[idx]


### PR DESCRIPTION
# Pull Request Description

## Summary
This PR enhances the `ClassificationPRCurve` and `ClassificationRocCurve` classes in the Evidently library to limit the number of points plotted in the Precision-Recall (PR) curve and the Receiver Operating Characteristic (ROC) curve to a maximum of 1000 points. This improvement helps to prevent performance issues when dealing with large datasets.

## Changes
- Introduced constants `PR_CURVE_MAX_POINTS` and `ROC_CURVE_MAX_POINTS` set to 1000.
- Added logic to downsample the PR and ROC curve data if exceed the defined maximum points to maintain performance.


## Conclusion
These changes improve the scalability of our metric calculations for classification performance while ensuring that users receive the most relevant information without overwhelming them with data.