### PR TITLE
SDK methods for datasets in Cloud.

### DIFF
--- a/src/evidently/sdk/datasets.py
+++ b/src/evidently/sdk/datasets.py
@@ -1,0 +1,112 @@
+import io
+import json
+import typing
+from datetime import datetime
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import pandas as pd
+from requests import Response
+
+from evidently import DataDefinition
+from evidently import Dataset
+from evidently._pydantic_compat import BaseModel
+from evidently._pydantic_compat import parse_obj_as
+from evidently.legacy.suite.base_suite import MetadataValueType
+from evidently.legacy.ui.workspace.cloud import NamedBytesIO
+from evidently.legacy.ui.workspace.cloud import read_multipart_response
+from evidently.sdk.models import SnapshotLink
+from evidently.ui.service.type_aliases import STR_UUID
+from evidently.ui.service.type_aliases import DatasetID
+from evidently.ui.service.type_aliases import ProjectID
+
+if typing.TYPE_CHECKING:
+    from evidently.ui.workspace import CloudWorkspace
+
+
+class DatasetInfo(BaseModel):
+    id: DatasetID
+    project_id: ProjectID
+    name: str
+    size_bytes: int
+    row_count: int
+    column_count: int
+    description: str
+    created_at: datetime
+    origin: str
+    tags: List[str]
+    metadata: Dict[str, MetadataValueType]
+
+
+class DatasetList(BaseModel):
+    datasets: List[DatasetInfo]
+
+    def __repr__(self):
+        return "\n\n".join(
+            f"Dataset: {d.name}\n"
+            f"ID: {d.id}\n"
+            f"Description: {d.description}\n"
+            f"Origin: {d.origin}\n"
+            f"Created: {d.created_at}\n"
+            f"Size: {d.size_bytes} bytes\n"
+            f"Row Count: {d.row_count} Column Count: {d.column_count}\n"
+            f"Tags: {', '.join(d.tags)}\n"
+            f"Metadata: {', '.join([f'{k}={v}' for k, v in d.metadata.items()])}"
+            for d in self.datasets
+        )
+
+
+class RemoteDatasetsManager:
+    def __init__(self, workspace: "CloudWorkspace"):
+        self._ws = workspace
+
+    def list(self, project: STR_UUID, origins: Optional[List[str]] = None) -> DatasetList:
+        return self._ws._request(
+            "/api/v2/datasets",
+            "GET",
+            query_params={"project_id": project, "origin": ",".join(origins) if origins else None},
+            response_model=DatasetList,
+        )
+
+    def load(self, dataset_id: DatasetID) -> Dataset:
+        response: Response = self._ws._request(f"/api/v2/datasets/{dataset_id}/download", "GET")
+
+        metadata, file_content = read_multipart_response(response)
+
+        df = pd.read_parquet(io.BytesIO(file_content))
+        data_def = parse_obj_as(DataDefinition, metadata["data_definition"])
+        return Dataset.from_pandas(df, data_definition=data_def)
+
+    def add(
+        self,
+        project_id: ProjectID,
+        dataset: Dataset,
+        name: str,
+        description: Optional[str] = None,
+        link: Optional[SnapshotLink] = None,
+    ):
+        data_definition = dataset.data_definition.json(exclude_none=True)
+        file = NamedBytesIO(b"", "data.parquet")
+        dataset.as_dataframe().to_parquet(file)
+        file.seek(0)
+        qp = {"project_id": project_id}
+        if link is not None:
+            qp["snapshot_id"] = link.snapshot_id
+            qp["dataset_type"] = link.dataset_type
+            qp["dataset_subtype"] = link.dataset_subtype
+        response: Response = self._ws._request(
+            "/api/v2/datasets/upload",
+            "POST",
+            body={
+                "name": name,
+                "description": description,
+                "file": file,
+                "data_definition_str": data_definition,
+                "metadata_str": json.dumps(dataset.metadata),
+                "tags_str": json.dumps(dataset.tags),
+            },
+            query_params=qp,
+            form_data=True,
+        )
+        return DatasetID(response.json()["dataset"]["id"])

--- a/src/evidently/ui/workspace.py
+++ b/src/evidently/ui/workspace.py
@@ -1,6 +1,4 @@
 import abc
-import io
-import json
 import os
 import uuid
 from abc import ABC
@@ -16,13 +14,10 @@ from typing import Union
 from typing import overload
 from urllib.parse import urljoin
 
-import pandas as pd
 from requests import HTTPError
 from requests import Response
 
 from evidently._pydantic_compat import BaseModel
-from evidently._pydantic_compat import parse_obj_as
-from evidently.core.datasets import DataDefinition
 from evidently.core.datasets import Dataset
 from evidently.core.report import Snapshot
 from evidently.core.serialization import SnapshotModel
@@ -39,10 +34,10 @@ from evidently.legacy.ui.type_aliases import ProjectID
 from evidently.legacy.ui.type_aliases import SnapshotID
 from evidently.legacy.ui.workspace.cloud import ACCESS_TOKEN_COOKIE
 from evidently.legacy.ui.workspace.cloud import TOKEN_HEADER_NAME
-from evidently.legacy.ui.workspace.cloud import NamedBytesIO
-from evidently.legacy.ui.workspace.cloud import read_multipart_response
 from evidently.legacy.ui.workspace.remote import RemoteBase
 from evidently.legacy.ui.workspace.remote import T
+from evidently.sdk.datasets import DatasetList
+from evidently.sdk.datasets import RemoteDatasetsManager
 from evidently.sdk.models import DashboardModel
 from evidently.sdk.models import DashboardPanelPlot
 from evidently.sdk.models import DashboardTabModel
@@ -576,6 +571,7 @@ class CloudWorkspace(RemoteWorkspace):
         self._logged_in: bool = False
         super().__init__(base_url=url if url is not None else self.URL)
         self.prompts = RemotePromptManager(self)
+        self.datasets = RemoteDatasetsManager(self)
 
     def _get_jwt_token(self):
         return super()._request("/api/users/login", "GET", headers={TOKEN_HEADER_NAME: self.token}).text
@@ -711,39 +707,13 @@ class CloudWorkspace(RemoteWorkspace):
         description: Optional[str],
         link: Optional[SnapshotLink] = None,
     ) -> DatasetID:
-        data_definition = dataset.data_definition.json(exclude_none=True)
-        file = NamedBytesIO(b"", "data.parquet")
-        dataset.as_dataframe().to_parquet(file)
-        file.seek(0)
-        qp = {"project_id": project_id}
-        if link is not None:
-            qp["snapshot_id"] = link.snapshot_id
-            qp["dataset_type"] = link.dataset_type
-            qp["dataset_subtype"] = link.dataset_subtype
-        response: Response = self._request(
-            "/api/v2/datasets/upload",
-            "POST",
-            body={
-                "name": name,
-                "description": description,
-                "file": file,
-                "data_definition_str": data_definition,
-                "metadata_str": json.dumps(dataset.metadata),
-                "tags_str": json.dumps(dataset.tags),
-            },
-            query_params=qp,
-            form_data=True,
-        )
-        return DatasetID(response.json()["dataset"]["id"])
+        return self.datasets.add(project_id=project_id, dataset=dataset, name=name, description=description, link=link)
 
     def load_dataset(self, dataset_id: DatasetID) -> Dataset:
-        response: Response = self._request(f"/api/v2/datasets/{dataset_id}/download", "GET")
+        return self.datasets.load(dataset_id)
 
-        metadata, file_content = read_multipart_response(response)
-
-        df = pd.read_parquet(io.BytesIO(file_content))
-        data_def = parse_obj_as(DataDefinition, metadata["data_definition"])
-        return Dataset.from_pandas(df, data_definition=data_def)
+    def list_datasets(self, project: STR_UUID, origins: Optional[List[str]] = None) -> DatasetList:
+        return self.datasets.list(project, origins=origins)
 
     def _get_snapshot_url(self, project_id: STR_UUID, snapshot_id: STR_UUID) -> str:
         return urljoin(self.base_url, f"/v2/projects/{project_id}/explore/{snapshot_id}")


### PR DESCRIPTION
Add new SDK section to work with datasets:
- `ws.datasets.add(...)` - add dataset to cloud, same as `ws.add_dataset(...)`
- `ws.datasets.load(...)` - load dataset from cloud, same as `ws.load_dataset(...)`
- (new) `ws.datasets.list(project_id, origins)` - retrieve list of datasets in project
  - `project_id` - Project ID to retrieve datasets from
  - `origins` (optional) - list of origins for datasets to filter out (default: None)
