### PR TITLE
Raising Exception for Missing `mean_tests` or `std_tests` in MAE Metric

### DIFF
--- a/src/evidently/metrics/regression.py
+++ b/src/evidently/metrics/regression.py
@@ -136,6 +136,11 @@ class MAE(MeanStdMetric):
     error_distr: bool = True
     error_normality: bool = False
 
+    def __init__(self, **kwargs):
+        if "tests" in kwargs:
+            raise ValueError("'tests' is not a valid argument for MAE. Did you mean 'mean_tests=' or 'std_tests='?")
+        super().__init__(**kwargs)
+
     def _default_tests_with_reference(self, context: Context) -> List[BoundTest]:
         return [eq(Reference(relative=0.1)).bind_mean_std(self.get_fingerprint(), True)]
 

--- a/src/evidently/metrics/regression.py
+++ b/src/evidently/metrics/regression.py
@@ -106,6 +106,11 @@ class MeanError(MeanStdMetric):
     error_distr: bool = False
     error_normality: bool = False
 
+    def __init__(self, **kwargs):
+        if "tests" in kwargs:
+            raise ValueError("'tests' is not a valid argument for MAE. Did you mean 'mean_tests=' or 'std_tests='?")
+        super().__init__(**kwargs)
+
     def _default_tests_with_reference(self, context: Context) -> List[BoundTest]:
         return [eq(Reference(relative=0.1)).bind_mean_std(self.get_fingerprint())]
 
@@ -199,6 +204,11 @@ class RMSECalculation(LegacyRegressionSingleValueMetric[RMSE]):
 class MAPE(MeanStdMetric):
     perc_error_plot: bool = True
     error_distr: bool = False
+
+    def __init__(self, **kwargs):
+        if "tests" in kwargs:
+            raise ValueError("'tests' is not a valid argument for MAE. Did you mean 'mean_tests=' or 'std_tests='?")
+        super().__init__(**kwargs)
 
     def _default_tests_with_reference(self, context: Context) -> List[BoundTest]:
         return [eq(Reference(relative=0.1)).bind_mean_std(self.get_fingerprint())]


### PR DESCRIPTION
### Description

This PR addresses issue #1627. Previously, passing `tests=[...]` to `MAE()` silently ignored the test, leading to unexpected results in reports. This could confuse users, especially when writing assertions based on the number of tests executed.

### Fix

- Added a check in the `MAE` class constructor to raise a `ValueError` if `tests` is provided instead of `mean_tests` or `std_tests`.
- The exception clearly instructs the user to use `mean_tests` or `std_tests` depending on what they want to test.

I had considered using a pydantic.Config class with extra = "forbid" to prevent accidental usage. It felt like a cleaner and more generalized solution for validating input.

However, I wasn't entirely sure if this would break other internal logic or dynamic field handling elsewhere in the codebase.

If this kind of config-based validation is acceptable or preferred, I'm happy to explore replacing the current manual ValueError check with a more declarative Pydantic approach. Let me know what you think!
