### PR TITLE
Improve Regression presets tests configuration.

### DIFF
--- a/src/evidently/core/metric_types.py
+++ b/src/evidently/core/metric_types.py
@@ -1184,6 +1184,17 @@ class MeanStdMetricTests(BaseModel):
         super().__init__(mean=convert_tests(mean), std=convert_tests(std))
 
 
+MeanStdMetricsPossibleTests = Union[MeanStdMetricTests, GenericSingleValueMetricTests, None]
+
+
+def convert_to_mean_tests(tests: MeanStdMetricsPossibleTests) -> Optional[MeanStdMetricTests]:
+    if tests is None:
+        return None
+    if isinstance(tests, MeanStdMetricTests):
+        return tests
+    return MeanStdMetricTests(mean=tests)
+
+
 class MeanStdMetric(Metric):
     mean_tests: SingleValueMetricTests = None
     std_tests: SingleValueMetricTests = None

--- a/src/evidently/core/metric_types.py
+++ b/src/evidently/core/metric_types.py
@@ -1192,7 +1192,11 @@ def convert_to_mean_tests(tests: MeanStdMetricsPossibleTests) -> Optional[MeanSt
         return None
     if isinstance(tests, MeanStdMetricTests):
         return tests
-    return MeanStdMetricTests(mean=tests)
+    if isinstance(tests, list):
+        return MeanStdMetricTests(mean=tests)
+    if isinstance(tests, dict):
+        return parse_obj_as(MeanStdMetricTests, tests)
+    raise ValueError(tests)
 
 
 class MeanStdMetric(Metric):

--- a/src/evidently/presets/regression.py
+++ b/src/evidently/presets/regression.py
@@ -6,7 +6,8 @@ from typing import Tuple
 from evidently._pydantic_compat import PrivateAttr
 from evidently.core.container import MetricContainer
 from evidently.core.container import MetricOrContainer
-from evidently.core.metric_types import GenericSingleValueMetricTests
+from evidently.core.metric_types import GenericSingleValueMetricTests, convert_to_mean_tests
+from evidently.core.metric_types import MeanStdMetricsPossibleTests
 from evidently.core.metric_types import MeanStdMetricTests
 from evidently.core.metric_types import MetricId
 from evidently.core.metric_types import SingleValueMetricTests
@@ -47,10 +48,10 @@ class RegressionQuality(MetricContainer):
         pred_actual_plot: bool = False,
         error_plot: bool = False,
         error_distr: bool = False,
-        mean_error_tests: Optional[MeanStdMetricTests] = None,
-        mape_tests: Optional[MeanStdMetricTests] = None,
+        mean_error_tests: MeanStdMetricsPossibleTests = None,
+        mape_tests: MeanStdMetricsPossibleTests = None,
         rmse_tests: GenericSingleValueMetricTests = None,
-        mae_tests: Optional[MeanStdMetricTests] = None,
+        mae_tests: MeanStdMetricsPossibleTests = None,
         r2score_tests: GenericSingleValueMetricTests = None,
         abs_max_error_tests: GenericSingleValueMetricTests = None,
         include_tests: bool = True,
@@ -58,10 +59,10 @@ class RegressionQuality(MetricContainer):
         self.pred_actual_plot = pred_actual_plot
         self.error_plot = error_plot
         self.error_distr = error_distr
-        self.mean_error_tests = mean_error_tests or MeanStdMetricTests()
-        self.mape_tests = mape_tests or MeanStdMetricTests()
+        self.mean_error_tests = convert_to_mean_tests(mean_error_tests) or MeanStdMetricTests()
+        self.mape_tests = convert_to_mean_tests(mape_tests) or MeanStdMetricTests()
         self.rmse_tests = convert_tests(rmse_tests)
-        self.mae_tests = mae_tests or MeanStdMetricTests()
+        self.mae_tests = convert_to_mean_tests(mae_tests) or MeanStdMetricTests()
         self.r2score_tests = convert_tests(r2score_tests)
         self.abs_max_error_tests = convert_tests(abs_max_error_tests)
         super().__init__(include_tests=include_tests)
@@ -159,19 +160,19 @@ class RegressionPreset(MetricContainer):
 
     def __init__(
         self,
-        mean_error_tests: Optional[MeanStdMetricTests] = None,
-        mape_tests: Optional[MeanStdMetricTests] = None,
+        mean_error_tests: MeanStdMetricsPossibleTests = None,
+        mape_tests: MeanStdMetricsPossibleTests = None,
         rmse_tests: GenericSingleValueMetricTests = None,
-        mae_tests: Optional[MeanStdMetricTests] = None,
+        mae_tests: MeanStdMetricsPossibleTests = None,
         r2score_tests: GenericSingleValueMetricTests = None,
         abs_max_error_tests: GenericSingleValueMetricTests = None,
         include_tests: bool = True,
     ):
         self._quality = None
-        self.mean_error_tests = mean_error_tests or MeanStdMetricTests()
-        self.mape_tests = mape_tests or MeanStdMetricTests()
+        self.mean_error_tests = convert_to_mean_tests(mean_error_tests) or MeanStdMetricTests()
+        self.mape_tests = convert_to_mean_tests(mape_tests) or MeanStdMetricTests()
         self.rmse_tests = convert_tests(rmse_tests)
-        self.mae_tests = mae_tests or MeanStdMetricTests()
+        self.mae_tests = convert_to_mean_tests(mae_tests) or MeanStdMetricTests()
         self.r2score_tests = convert_tests(r2score_tests)
         self.abs_max_error_tests = convert_tests(abs_max_error_tests)
         super().__init__(include_tests=include_tests)

--- a/src/evidently/presets/regression.py
+++ b/src/evidently/presets/regression.py
@@ -6,12 +6,13 @@ from typing import Tuple
 from evidently._pydantic_compat import PrivateAttr
 from evidently.core.container import MetricContainer
 from evidently.core.container import MetricOrContainer
-from evidently.core.metric_types import GenericSingleValueMetricTests, convert_to_mean_tests
+from evidently.core.metric_types import GenericSingleValueMetricTests
 from evidently.core.metric_types import MeanStdMetricsPossibleTests
 from evidently.core.metric_types import MeanStdMetricTests
 from evidently.core.metric_types import MetricId
 from evidently.core.metric_types import SingleValueMetricTests
 from evidently.core.metric_types import convert_tests
+from evidently.core.metric_types import convert_to_mean_tests
 from evidently.core.report import Context
 from evidently.legacy.metrics import RegressionDummyMetric
 from evidently.legacy.metrics import RegressionErrorDistribution

--- a/tests/future/presets/regression.py
+++ b/tests/future/presets/regression.py
@@ -15,6 +15,7 @@ from evidently.tests import lt
     [
         (RegressionQuality(), 0),
         (RegressionQuality(mean_error_tests=MeanStdMetricTests(mean=[lt(0.1)])), 1),
+        (RegressionQuality(mean_error_tests=[lt(0.1)]), 1),
         (RegressionQuality(mean_error_tests=MeanStdMetricTests(std=[lt(0.1)])), 1),
         (RegressionQuality(mae_tests=MeanStdMetricTests(mean=[lt(0.1)])), 1),
         (RegressionQuality(mae_tests=MeanStdMetricTests(std=[lt(0.1)])), 1),


### PR DESCRIPTION
Add new way to configure tests in Regression presets:

```
RegressionQuality(mean_error_tests=[lt(0.1)], mae_tests=[lt(0.1)], mape_tests=[lt(0.1)])
```

In this case, tests would be applied to `mean` value by default.