### PR TITLE
Minor improvement for metric tests

### DIFF
--- a/src/evidently/metrics/regression.py
+++ b/src/evidently/metrics/regression.py
@@ -130,6 +130,12 @@ class MeanErrorCalculation(LegacyRegressionMeanStdMetric[MeanError]):
     def display_name(self) -> str:
         return "Mean Error"
 
+    def mean_display_name(self) -> str:
+        return "Mean Error"
+
+    def std_display_name(self) -> str:
+        return "Std Error"
+
 
 class MAE(MeanStdMetric):
     error_plot: bool = False
@@ -163,6 +169,12 @@ class MAECalculation(LegacyRegressionMeanStdMetric[MAE]):
 
     def display_name(self) -> str:
         return "Mean Absolute Error"
+
+    def mean_display_name(self) -> str:
+        return "Mean Absolute Error"
+
+    def std_display_name(self) -> str:
+        return "Std Absolute Error"
 
 
 class RMSE(SingleValueMetric):
@@ -216,6 +228,12 @@ class MAPECalculation(LegacyRegressionMeanStdMetric[MAPE]):
 
     def display_name(self) -> str:
         return "Mean Absolute Percentage Error"
+
+    def mean_display_name(self) -> str:
+        return "Mean Absolute Percentage Error"
+
+    def std_display_name(self) -> str:
+        return "Std Absolute Percentage Error"
 
 
 class R2Score(SingleValueMetric):

--- a/src/evidently/tests/numerical_tests.py
+++ b/src/evidently/tests/numerical_tests.py
@@ -33,10 +33,6 @@ class ComparisonTest(MetricTest):
         def func(context: Context, metric: MetricCalculationBase, value: SingleValue):
             threshold = self.get_threshold(context, value.get_metric_value_location())
             title_threshold = f"{threshold:0.3f}"
-            if isinstance(self.threshold, Reference):
-                title_threshold = "Reference"
-                if isinstance(threshold, ApproxValue):
-                    title_threshold += f" ± {threshold.tolerance:0.3f}"
             return MetricTestResult(
                 id=self.__short_name__,
                 name=f"{value.display_name}: {self.__full_name__} {title_threshold}",
@@ -104,10 +100,6 @@ class EqualMetricTestBase(MetricTest, abc.ABC):
         else:
             expected = self.expected
         title_expected = f"{expected:0.3f}"
-        if isinstance(self.expected, Reference):
-            title_expected = "Reference"
-            if isinstance(expected, ApproxValue):
-                title_expected += f" ± {expected.tolerance:0.3f}"
         return expected, title_expected, expected == value.value
 
 
@@ -120,7 +112,8 @@ class EqualMetricTest(EqualMetricTestBase):
             return MetricTestResult(
                 id="eq",
                 name=f"{metric.display_name()}: Equal {title_expected}",
-                description=f"Actual value {value.value:0.3f} {f', but expected {expected:0.3f}' if not is_equal else ''}",
+                description=f"Actual value {value.value:0.3f}"
+                f" {f', but expected {expected:0.3f}' if not is_equal else f' expected {expected:0.3f}'}",
                 status=TestStatus.SUCCESS if is_equal else TestStatus.FAIL,
                 metric_config=metric.to_metric_config(),
                 test_config=self.dict(),
@@ -136,7 +129,8 @@ class NotEqualMetricTest(EqualMetricTestBase):
             return MetricTestResult(
                 id="not_eq",
                 name=f"{metric.display_name()}: Not equal {title_expected}",
-                description=f"Actual value {value.value} {f', but expected not {expected}' if is_equal else ''}",
+                description=f"Actual value {value.value}"
+                f" {f', but expected not {expected}' if is_equal else f' expected {expected:0.3f}'}",
                 status=TestStatus.SUCCESS if not is_equal else TestStatus.FAIL,
                 metric_config=metric.to_metric_config(),
                 test_config=self.dict(),

--- a/src/evidently/tests/numerical_tests.py
+++ b/src/evidently/tests/numerical_tests.py
@@ -33,6 +33,11 @@ class ComparisonTest(MetricTest):
         def func(context: Context, metric: MetricCalculationBase, value: SingleValue):
             threshold = self.get_threshold(context, value.get_metric_value_location())
             title_threshold = f"{threshold:0.3f}"
+            if isinstance(self.threshold, Reference):
+                if isinstance(threshold, ApproxValue):
+                    title_threshold += f"Reference {threshold:0.3f} ± {threshold.tolerance:0.3f}"
+                else:
+                    title_threshold = f"Reference {threshold:0.3f}"
             return MetricTestResult(
                 id=self.__short_name__,
                 name=f"{value.display_name}: {self.__full_name__} {title_threshold}",
@@ -130,7 +135,7 @@ class NotEqualMetricTest(EqualMetricTestBase):
                 id="not_eq",
                 name=f"{metric.display_name()}: Not equal {title_expected}",
                 description=f"Actual value {value.value}"
-                f" {f', but expected not {expected}' if is_equal else f' expected {expected:0.3f}'}",
+                f" {f', but expected not {expected:0.3f}' if is_equal else f' not equal to {expected:0.3f}'}",
                 status=TestStatus.SUCCESS if not is_equal else TestStatus.FAIL,
                 metric_config=metric.to_metric_config(),
                 test_config=self.dict(),


### PR DESCRIPTION
1) Reformat title in `Equal to` tests with Reference values to include exact value.
2) Change display name for `MeanError`, `MAE` and `MAPE` metric in tests to match testing value (mean or std) depending on provided tests.