### PR TITLE
Fix NotImplementedError when using tests with Generators

### DIFF
--- a/src/evidently/generators/column.py
+++ b/src/evidently/generators/column.py
@@ -61,7 +61,7 @@ class ColumnMetricGenerator(MetricContainer):
         self.columns = columns
         self.column_types = column_types
         self.metric_kwargs = metric_kwargs or {}
-        super().__init__(include_tests=True)
+        super().__init__(include_tests=include_tests)
 
     def _instantiate_metric(self, column: str) -> MetricOrContainer:
         return self._metric_type(column=column, **self.metric_kwargs)

--- a/src/evidently/generators/column.py
+++ b/src/evidently/generators/column.py
@@ -39,6 +39,7 @@ class ColumnMetricGenerator(MetricContainer):
         metric_kwargs: Optional[Dict[str, Any]] = None,
         metric_type_alias: Optional[str] = None,
         include_tests: bool = True,
+        **kwargs,
     ):
         if isinstance(metric_type, type):
             assert issubclass(metric_type, ColumnMetric) or issubclass(
@@ -60,7 +61,9 @@ class ColumnMetricGenerator(MetricContainer):
         self._metric_type = _metric_type
         self.columns = columns
         self.column_types = column_types
-        self.metric_kwargs = metric_kwargs or {}
+        if metric_kwargs and kwargs:
+            raise ValueError("only one of metric_kwargs or **kwargs may be specified")
+        self.metric_kwargs = metric_kwargs or kwargs or {}
         super().__init__(include_tests=include_tests)
 
     def _instantiate_metric(self, column: str) -> MetricOrContainer:

--- a/src/evidently/tests/aliases.py
+++ b/src/evidently/tests/aliases.py
@@ -6,7 +6,6 @@ from typing import overload
 
 from evidently.core.datasets import DescriptorTest
 from evidently.core.metric_types import MetricTest
-from evidently.core.tests import FactoryGenericTest
 from evidently.core.tests import GenericTest
 from evidently.tests.categorical_tests import InValueType
 from evidently.tests.categorical_tests import IsInMetricTest
@@ -29,6 +28,8 @@ from evidently.tests.numerical_tests import ThresholdType
 
 AnyTest = Union[GenericTest, MetricTest, DescriptorTest]
 
+GenericTest.update_forward_refs(MetricTest=MetricTest, DescriptorTest=DescriptorTest)
+
 
 @overload
 def eq(expected: Any) -> GenericTest: ...
@@ -45,9 +46,10 @@ def eq(expected: Any, *, column: Optional[str] = None, alias: Optional[str] = No
 def eq(
     expected: ThresholdType, *, is_critical: bool = True, column: Optional[str] = None, alias: Optional[str] = None
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: EqualMetricTest(expected=expected, is_critical=is_critical),
-        lambda: DescriptorTest(condition=EqualsColumnCondition(expected=expected), column=column, alias=alias),
+    return GenericTest(
+        test_name="eq",
+        metric=EqualMetricTest(expected=expected, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=EqualsColumnCondition(expected=expected), column=column, alias=alias),
     )
 
 
@@ -66,9 +68,10 @@ def not_eq(expected: Any, *, column: Optional[str] = None, alias: Optional[str] 
 def not_eq(
     expected: ThresholdType, *, is_critical: bool = True, column: Optional[str] = None, alias: Optional[str] = None
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: NotEqualMetricTest(expected=expected, is_critical=is_critical),
-        lambda: DescriptorTest(condition=NotEqualsColumnCondition(expected=expected), column=column, alias=alias),
+    return GenericTest(
+        test_name="not_eq",
+        metric=NotEqualMetricTest(expected=expected, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=NotEqualsColumnCondition(expected=expected), column=column, alias=alias),
     )
 
 
@@ -87,9 +90,10 @@ def lt(threshold: ThresholdType, *, column: Optional[str] = None, alias: Optiona
 def lt(
     threshold: ThresholdType, *, is_critical: bool = True, column: Optional[str] = None, alias: Optional[str] = None
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: LessThanMetricTest(threshold=threshold, is_critical=is_critical),
-        lambda: DescriptorTest(condition=LessColumnCondition(threshold=threshold), column=column, alias=alias),
+    return GenericTest(
+        test_name="lt",
+        metric=LessThanMetricTest(threshold=threshold, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=LessColumnCondition(threshold=threshold), column=column, alias=alias),
     )
 
 
@@ -108,9 +112,10 @@ def gt(threshold: ThresholdType, *, column: Optional[str] = None, alias: Optiona
 def gt(
     threshold: ThresholdType, *, is_critical: bool = True, column: Optional[str] = None, alias: Optional[str] = None
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: GreaterThanMetricTest(threshold=threshold, is_critical=is_critical),
-        lambda: DescriptorTest(condition=GreaterColumnCondition(threshold=threshold), column=column, alias=alias),
+    return GenericTest(
+        test_name="gt",
+        metric=GreaterThanMetricTest(threshold=threshold, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=GreaterColumnCondition(threshold=threshold), column=column, alias=alias),
     )
 
 
@@ -129,9 +134,12 @@ def gte(threshold: ThresholdType, *, column: Optional[str] = None, alias: Option
 def gte(
     threshold: ThresholdType, *, is_critical: bool = True, column: Optional[str] = None, alias: Optional[str] = None
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: GreaterOrEqualMetricTest(threshold=threshold, is_critical=is_critical, alias=alias),
-        lambda: DescriptorTest(condition=GreaterEqualColumnCondition(threshold=threshold), column=column, alias=alias),
+    return GenericTest(
+        test_name="gte",
+        metric=GreaterOrEqualMetricTest(threshold=threshold, is_critical=is_critical, alias=alias),
+        descriptor=DescriptorTest(
+            condition=GreaterEqualColumnCondition(threshold=threshold), column=column, alias=alias
+        ),
     )
 
 
@@ -150,9 +158,10 @@ def lte(threshold: ThresholdType, *, column: Optional[str] = None, alias: Option
 def lte(
     threshold: ThresholdType, *, is_critical: bool = True, column: Optional[str] = None, alias: Optional[str] = None
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: LessOrEqualMetricTest(threshold=threshold, is_critical=is_critical),
-        lambda: DescriptorTest(condition=LessEqualColumnCondition(threshold=threshold), column=column, alias=alias),
+    return GenericTest(
+        test_name="lte",
+        metric=LessOrEqualMetricTest(threshold=threshold, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=LessEqualColumnCondition(threshold=threshold), column=column, alias=alias),
     )
 
 
@@ -177,9 +186,10 @@ def is_in(
     column: Optional[str] = None,
     alias: Optional[str] = None,
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: IsInMetricTest(values=values, is_critical=is_critical),
-        lambda: DescriptorTest(condition=IsInColumnCondition(values=set(values)), column=column, alias=alias),
+    return GenericTest(
+        test_name="is_in",
+        metric=IsInMetricTest(values=values, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=IsInColumnCondition(values=set(values)), column=column, alias=alias),
     )
 
 
@@ -204,7 +214,8 @@ def not_in(
     column: Optional[str] = None,
     alias: Optional[str] = None,
 ) -> AnyTest:
-    return FactoryGenericTest(
-        lambda: NotInMetricTest(values=values, is_critical=is_critical),
-        lambda: DescriptorTest(condition=IsNotInColumnCondition(values=set(values)), column=column, alias=alias),
+    return GenericTest(
+        test_name="not_in",
+        metric=NotInMetricTest(values=values, is_critical=is_critical),
+        descriptor=DescriptorTest(condition=IsNotInColumnCondition(values=set(values)), column=column, alias=alias),
     )

--- a/tests/future/generators/test_generator.py
+++ b/tests/future/generators/test_generator.py
@@ -3,6 +3,7 @@ import pandas as pd
 from evidently.core.report import Report
 from evidently.generators import ColumnMetricGenerator
 from evidently.presets import ValueStats
+from evidently.tests import gt
 
 
 def test_generator_renders():
@@ -10,3 +11,10 @@ def test_generator_renders():
     report = Report([generator])
     snapshot = report.run(pd.DataFrame(data={"a": [1, 2, 3, 4], "b": [1, 2, 3, 4]}))
     assert len(snapshot._widgets) == 2
+
+
+def test_generator_kwargs():
+    generator = ColumnMetricGenerator(ValueStats, columns=["a", "b"], metric_kwargs={"tests": [gt(0)]})
+    generator2 = ColumnMetricGenerator(ValueStats, columns=["a", "b"], tests=[gt(0)])
+
+    assert generator.dict() == generator2.dict()

--- a/tests/future/presets/test_serialization.py
+++ b/tests/future/presets/test_serialization.py
@@ -21,6 +21,7 @@ from evidently.presets import RegressionDummyQuality
 from evidently.presets import RegressionPreset
 from evidently.presets import RegressionQuality
 from evidently.presets import TextEvals
+from evidently.tests import gt
 from tests.conftest import load_all_subtypes
 
 load_all_subtypes(MetricContainer)
@@ -31,7 +32,8 @@ all_presets: List[MetricContainer] = [
     DatasetStats(),
     DataSummaryPreset(),
     RegressionDummyQuality(),
-    ColumnMetricGenerator(metric_type=MinValue),
+    ColumnMetricGenerator(metric_type=MinValue, metric_kwargs={"tests": [gt(0)]}),
+    ColumnMetricGenerator(metric_type=MinValue, tests=[gt(0)]),
     ClassificationDummyQuality(),
     RegressionQuality(),
     DataDriftPreset(),


### PR DESCRIPTION
Fix NotImplementedError when using tests in metric_kwargs in ColumnMetricGenerator.

Also support for passing metric kwargs directly to generator:

Example:
```
ColumnMetricGenerator(MinValue, tests=[gt(0)])
```