### PR TITLE
Conform with Numpy v2 requirements

### DIFF
--- a/src/evidently/legacy/metrics/recsys/pairwise_distance.py
+++ b/src/evidently/legacy/metrics/recsys/pairwise_distance.py
@@ -62,11 +62,11 @@ class PairwiseDistance(Metric[PairwiseDistanceResult]):
         all_items = all_items[all_items[prediction_name] <= self.k + 1]
         all_items = all_items[[item_id.column_name] + self.item_features]
         if current_train_data is not None:
-            if not np.in1d(self.item_features, current_train_data.columns).all():  # type: ignore[attr-defined]
+            if not np.isin(self.item_features, current_train_data.columns).all():  # type: ignore[attr-defined]
                 raise ValueError("current_train_data must contain item_features.")
             all_items = pd.concat([all_items, current_train_data[[item_id.column_name] + self.item_features]])
         if reference_train_data is not None:
-            if not np.in1d(self.item_features, reference_train_data.columns).all():  # type: ignore[attr-defined]
+            if not np.isin(self.item_features, reference_train_data.columns).all():  # type: ignore[attr-defined]
                 raise ValueError("reference_train_data must contain item_features.")
             all_items = pd.concat([all_items, reference_train_data[[item_id.column_name] + self.item_features]])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from evidently.pydantic_utils import TYPE_ALIASES
 from evidently.pydantic_utils import PolymorphicModel
 
 # for np.testing.assert_equal to work with ApproxValue
-np.core.numeric.ScalarType = np.core.numeric.ScalarType + (ApproxValue,)  # type: ignore[attr-defined]
+np._core.numeric.ScalarType = np._core.numeric.ScalarType + (ApproxValue,)  # type: ignore[attr-defined]
 
 
 def smart_assert_equal(actual, expected, path=""):


### PR DESCRIPTION
Numpy's major version 2 has been released one year ago. This PR changes minor things to remove deprecation warnings when using Numpy version 2.