### PR TITLE
Add descriptive error messages for missing classification metrics

### DIFF
--- a/src/evidently/metrics/classification.py
+++ b/src/evidently/metrics/classification.py
@@ -385,7 +385,10 @@ class TPRCalculation(LegacyClassificationQuality[TPR]):
         render: List[BaseWidgetInfo],
     ) -> Tuple[SingleValue, Optional[SingleValue]]:
         if legacy_result.current.tpr is None:
-            raise ValueError("Failed to calculate TPR value")
+            raise ValueError(
+                "Cannot compute TPR: current TPR value is missing. "
+                "Ensure prediction labels and probabilities are available. "
+            )
         return (
             self.result(legacy_result.current.tpr),
             None
@@ -413,7 +416,10 @@ class TNRCalculation(LegacyClassificationQuality[TNR]):
         render: List[BaseWidgetInfo],
     ) -> Tuple[SingleValue, Optional[SingleValue]]:
         if legacy_result.current.tnr is None:
-            raise ValueError("Failed to calculate TNR value")
+            raise ValueError(
+                "Cannot compute TNR: current TNR value is missing. "
+                "Ensure prediction labels and probabilities are available. "
+            )
         return (
             self.result(legacy_result.current.tnr),
             None
@@ -441,7 +447,10 @@ class FPRCalculation(LegacyClassificationQuality[FPR]):
         render: List[BaseWidgetInfo],
     ) -> Tuple[SingleValue, Optional[SingleValue]]:
         if legacy_result.current.fpr is None:
-            raise ValueError("Failed to calculate FPR value")
+            raise ValueError(
+                "Cannot compute FPR: current FPR value is missing. "
+                "Ensure prediction labels and probabilities are available. "
+            )
         return (
             self.result(legacy_result.current.fpr),
             None
@@ -469,7 +478,10 @@ class FNRCalculation(LegacyClassificationQuality[FNR]):
         render: List[BaseWidgetInfo],
     ) -> Tuple[SingleValue, Optional[SingleValue]]:
         if legacy_result.current.fnr is None:
-            raise ValueError("Failed to calculate FNR value")
+            raise ValueError(
+                "Cannot compute FNR: current FNR value is missing. "
+                "Ensure prediction labels and probabilities are available. "
+            )
         return (
             self.result(legacy_result.current.fnr),
             None
@@ -498,7 +510,10 @@ class RocAucCalculation(LegacyClassificationQuality[RocAuc]):
         render: List[BaseWidgetInfo],
     ) -> Tuple[SingleValue, Optional[SingleValue]]:
         if legacy_result.current.roc_auc is None:
-            raise ValueError("Failed to calculate RocAuc value")
+            raise ValueError(
+                "Cannot compute RocAuc: current RocAuc value is missing. "
+                "Ensure prediction labels and probabilities are available. "
+            )
         return (
             self.result(legacy_result.current.roc_auc),
             None
@@ -526,7 +541,10 @@ class LogLossCalculation(LegacyClassificationQuality[LogLoss]):
         render: List[BaseWidgetInfo],
     ) -> Tuple[SingleValue, Optional[SingleValue]]:
         if legacy_result.current.log_loss is None:
-            raise ValueError("Failed to calculate LogLoss value")
+            raise ValueError(
+                "Cannot compute LogLoss: current LogLoss value is missing. "
+                "Ensure prediction labels and probabilities are available. "
+            )
         return (
             self.result(legacy_result.current.log_loss),
             None


### PR DESCRIPTION
In my experience, classification error metrics such as TNR, FNR, FPR, and others often fail to compute due to missing or malformed predicted labels or probabilities. To improve user experience and facilitate debugging, I’ve added explicit ValueError messages in the classification.py module to inform users of this likely cause when the metric computation fails.

Changes made: Added informative ValueError messages in the following metric calculations:

- True Negative Rate (TNR)
- False Negative Rate (FNR)
- False Positive Rate (FPR)
- True Predictive Rate (TPR)
- Area Under the ROC (RocAuc)
- Log Loss

The added messages follow the format:

Cannot compute [metric]: current [metric] value is missing. Ensure prediction labels and probabilities are available.

Testing:

- Ran ruff check and ruff format — all style and formatting checks passed
- Ran mypy src/evidently/metrics/classification.py — no issues reported
- Ran pytest -v tests — all tests passed. A single test collection warning was observed in a file unrelated to the modified metric calculation module. No new test failures introduced. 

This is my first time contributing to an open-source ML project. I’ve followed Evidently’s contribution guidelines to the best of my ability, but please let me know if I’ve missed anything or if there’s a better way to structure this change. I’d be grateful for your feedback!