### PR TITLE
Fix variable used in TestSummaryInfo.has_all

### DIFF
--- a/src/evidently/core/datasets.py
+++ b/src/evidently/core/datasets.py
@@ -492,7 +492,7 @@ class TestSummaryInfo(SpecialColumnInfo):
 
     @property
     def has_all(self):
-        return self.any_column is not None
+        return self.all_column is not None
 
     @property
     def has_any(self):


### PR DESCRIPTION
I think this is just a small mistake.
The intended field to check should be `self.all_column`.

```
    @property
    def has_all(self):
        return self.any_column is not None
✅      return self.all_column is not None

    @property
    def has_any(self):
        return self.any_column is not None
```