### PR TITLE
 Database Authentication Failures Due to Password Masking in Migration

### DIFF
--- a/src/evidently/ui/service/storage/sql/utils.py
+++ b/src/evidently/ui/service/storage/sql/utils.py
@@ -22,7 +22,7 @@ def create_engine_and_migrate(engine: Engine) -> Engine:
     # Run migrations on startup (fallback to create_all if migrations not initialized)
     try:
         logger.info("Running database migrations...")
-        migrate_database(str(engine.url))
+        migrate_database(engine.url.render_as_string(hide_password=False))
         logger.info("Database migrations completed successfully")
     except (FileNotFoundError, ImportError):
         # Migrations not available - use create_all


### PR DESCRIPTION
## Description
Fixes #1766

This PR resolves database connection failures during migration caused by password masking in the database URL string.

## Problem
The current implementation uses `str(engine.url)` which masks the password as `***`, causing authentication failures when attempting to connect to the database during migration. This affects all database types (PostgreSQL, MySQL, RDS, etc.).

## Solution
Changed line 26 in `src/evidently/ui/service/storage/sql/utils.py` to use:
```python
migrate_database(engine.url.render_as_string(hide_password=False))
```

This explicitly tells SQLAlchemy to include the actual password in the connection string by using `hide_password=False`.

## Changes
- Updated `create_engine_and_migrate()` function in `src/evidently/ui/service/storage/sql/utils.py`
- Changed from `str(engine.url)` to `engine.url.render_as_string(hide_password=False)`

## Testing
- ✅ Tested with AWS RDS PostgreSQL database
- ✅ Database migration completes successfully
- ✅ Authentication errors resolved

## Impact
This fix enables Evidently to properly connect to external databases during the migration step, resolving authentication failures that were preventing users from using the platform with external database configurations.

@adrianAzoitei