### PR TITLE
Fix Groupby display name for Valuedrift metrics

### DIFF
--- a/src/evidently/metrics/group_by.py
+++ b/src/evidently/metrics/group_by.py
@@ -35,8 +35,6 @@ class GroupByMetricCalculation(MetricCalculation[TResult, GroupByMetric]):
     def calculate(self, context: "Context", current_data: Dataset, reference_data: Optional[Dataset]):
         curr = current_data.subdataset(self.metric.column_name, self.metric.label)
         ref = reference_data.subdataset(self.metric.column_name, self.metric.label) if reference_data else None
-        dn = self.calculation.display_name
-        self.calculation.display_name = _patched_display_name(dn, self.metric)  # type: ignore[method-assign]
         res = self.calculation.calculate(context, curr, ref)
         if isinstance(res, tuple):
             curr_res, ref_res = res
@@ -48,9 +46,8 @@ class GroupByMetricCalculation(MetricCalculation[TResult, GroupByMetric]):
         return curr_res, ref_res
 
     def display_name(self) -> str:
-        return (
-            f"{self.calculation.display_name()} group by '{self.metric.column_name}' for label: '{self.metric.label}'"
-        )
+        base = self.calculation.display_name()
+        return f"{base} group by '{self.metric.column_name}' for label: '{self.metric.label}'"
 
     @property
     def column_name(self) -> str:


### PR DESCRIPTION
## Fix GroupBy display name for ValueDrift metrics

### Problem

`GroupBy(ValueDrift(...))` does not include the group-by column name and label in the report display name, while other metrics such as `MaxValue` do.

This results in inconsistent output:

* `GroupBy(MaxValue(...))` → includes group-by column and label
* `GroupBy(ValueDrift(...))` → shows only `Drift in column '<column>'`

Reported in #1706.

---

### Root cause

`GroupByMetricCalculation` relied on metric-specific internal display name generation. For `ValueDrift`, this display name does not carry group-by context, so the column name and label were lost.

---

### Fix

Build the display name explicitly in `GroupByMetricCalculation.display_name()` using:

* the base display name of the underlying metric
* the group-by column name
* the group label

This makes the behavior consistent across all `GroupBy` metrics.

---

### Implementation

**File:**

```
src/evidently/metrics/group_by.py
```

The display name construction was moved to the GroupBy calculation layer instead of relying on metric-specific behavior.

---

### Result

`GroupBy(ValueDrift(...))` now displays:

```
Drift in column '<column>' group by '<group_column>' for label: '<label>'
```

---

### Testing

* Reproduced the issue locally using the example from #1706
* Verified output for both `MaxValue` and `ValueDrift`
* Formatting and lint checks pass
