### PR TITLE
fix: Add pagination to reports table to fix UI performance

### DIFF
--- a/ui/packages/evidently-ui-lib/src/routes-components/snapshots/index.tsx
+++ b/ui/packages/evidently-ui-lib/src/routes-components/snapshots/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import {
   Box,


### PR DESCRIPTION
Implements table pagination in SnapshotsListTemplate component to address performance issues when displaying 1000+ reports. Previously, the UI rendered all reports at once causing significant slowdown with large datasets.
Changes:

- Add pagination state management (page, rowsPerPage)
- Implement paginatedSnapshots to slice filtered results
- Add TablePagination component with custom navigation controls
- Reset pagination when filters change

Fixes #1795