### PR TITLE
Support target_names in classification metrics renderers

### DIFF
--- a/src/evidently/legacy/metrics/classification_performance/class_separation_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/class_separation_metric.py
@@ -18,6 +18,7 @@ from evidently.legacy.metric_results import df_from_column_scatter
 from evidently.legacy.metric_results import raw_agg_properties
 from evidently.legacy.model.widget import BaseWidgetInfo
 from evidently.legacy.options.base import AnyOptions
+from evidently.legacy.pipeline.column_mapping import TargetNames
 from evidently.legacy.renderers.base_renderer import MetricRenderer
 from evidently.legacy.renderers.base_renderer import default_renderer
 from evidently.legacy.renderers.html_widgets import TabData
@@ -40,6 +41,7 @@ class ClassificationClassSeparationPlotResults(MetricResult):
         }
 
     target_name: str
+    target_names: Optional[TargetNames] = None
 
     current: Optional[ColumnScatterOrAgg] = None
     current_raw, current_agg = raw_agg_properties("current", ColumnScatter, ColumnAggScatter, True)
@@ -107,6 +109,7 @@ class ClassificationClassSeparationPlot(UsesRawDataMixin, Metric[ClassificationC
                 current=column_scatter_from_df(current_plot, True),
                 reference=column_scatter_from_df(reference_plot, True),
                 target_name=target_name,
+                target_names=dataset_columns.target_names,
             )
         current_plot = prepare_box_data(current_plot, target_name, prediction_names.tolist())
         if reference_plot is not None:
@@ -115,7 +118,16 @@ class ClassificationClassSeparationPlot(UsesRawDataMixin, Metric[ClassificationC
             current=current_plot,
             reference=reference_plot,
             target_name=target_name,
+            target_names=dataset_columns.target_names,
         )
+
+
+def _resolve_target_name(label, target_names: Optional[TargetNames]) -> str:
+    if target_names is not None and isinstance(target_names, dict):
+        resolved = target_names.get(label) or target_names.get(int(label)) if isinstance(label, str) else target_names.get(label)  # type: ignore[arg-type]
+        if resolved is not None:
+            return str(resolved)
+    return str(label)
 
 
 @default_renderer(wrap_type=ClassificationClassSeparationPlot)
@@ -150,7 +162,7 @@ class ClassificationClassSeparationPlotRenderer(MetricRenderer):
                 target_name,
                 color_options=self.color_options,
             )
-        tabs = [TabData(name, widget) for name, widget in tab_data]
+        tabs = [TabData(_resolve_target_name(name, metric_result.target_names), widget) for name, widget in tab_data]
         return [
             header_text(label="Class Separation Quality"),
             widget_tabs(title="", tabs=tabs),

--- a/src/evidently/legacy/metrics/classification_performance/probability_distribution_metric.py
+++ b/src/evidently/legacy/metrics/classification_performance/probability_distribution_metric.py
@@ -13,6 +13,7 @@ from evidently.legacy.base_metric import MetricResult
 from evidently.legacy.calculations.classification_performance import get_prediction_data
 from evidently.legacy.core import IncludeTags
 from evidently.legacy.model.widget import BaseWidgetInfo
+from evidently.legacy.pipeline.column_mapping import TargetNames
 from evidently.legacy.renderers.base_renderer import MetricRenderer
 from evidently.legacy.renderers.base_renderer import default_renderer
 from evidently.legacy.renderers.html_widgets import GraphData
@@ -32,6 +33,7 @@ class ClassificationProbDistributionResults(MetricResult):
 
     current_distribution: Optional[Dict[str, list]]  # todo use DistributionField?
     reference_distribution: Optional[Dict[str, list]]
+    target_names: Optional[TargetNames] = None
 
 
 class ClassificationProbDistribution(Metric[ClassificationProbDistributionResults]):
@@ -93,19 +95,29 @@ class ClassificationProbDistribution(Metric[ClassificationProbDistributionResult
         return ClassificationProbDistributionResults(
             current_distribution=current_distribution,
             reference_distribution=reference_distribution,
+            target_names=columns.target_names,
         )
 
 
 @default_renderer(wrap_type=ClassificationProbDistribution)
 class ClassificationProbDistributionRenderer(MetricRenderer):
-    def _plot(self, distribution: Dict[str, list]):
+    @staticmethod
+    def _resolve_target_name(label, target_names: Optional[TargetNames]) -> str:
+        if target_names is not None and isinstance(target_names, dict):
+            resolved = target_names.get(label) or target_names.get(int(label)) if isinstance(label, str) else target_names.get(label)  # type: ignore[arg-type]
+            if resolved is not None:
+                return str(resolved)
+        return str(label)
+
+    def _plot(self, distribution: Dict[str, list], target_names: Optional[TargetNames] = None):
         # plot distributions
         graphs = []
 
         for label in distribution:
+            display_name = self._resolve_target_name(label, target_names)
             pred_distr = ff.create_distplot(
                 distribution[label],
-                [str(label), "other"],
+                [display_name, "other"],
                 colors=[
                     self.color_options.primary_color,
                     self.color_options.secondary_color,
@@ -123,7 +135,7 @@ class ClassificationProbDistributionRenderer(MetricRenderer):
             pred_distr_json = pred_distr.to_plotly_json()
             graphs.append(
                 {
-                    "title": str(label),
+                    "title": display_name,
                     "data": pred_distr_json["data"],
                     "layout": pred_distr_json["layout"],
                 }
@@ -134,6 +146,7 @@ class ClassificationProbDistributionRenderer(MetricRenderer):
         metric_result = obj.get_result()
         reference_distribution = metric_result.reference_distribution
         current_distribution = metric_result.current_distribution
+        target_names = metric_result.target_names
         result = []
         size = WidgetSize.FULL
 
@@ -147,7 +160,7 @@ class ClassificationProbDistributionRenderer(MetricRenderer):
                     size=size,
                     figures=[
                         GraphData(graph["title"], graph["data"], graph["layout"])
-                        for graph in self._plot(current_distribution)
+                        for graph in self._plot(current_distribution, target_names)
                     ],
                 )
             )
@@ -159,7 +172,7 @@ class ClassificationProbDistributionRenderer(MetricRenderer):
                     size=size,
                     figures=[
                         GraphData(graph["title"], graph["data"], graph["layout"])
-                        for graph in self._plot(reference_distribution)
+                        for graph in self._plot(reference_distribution, target_names)
                     ],
                 )
             )

--- a/src/evidently/legacy/metrics/classification_performance/quality_by_feature_table.py
+++ b/src/evidently/legacy/metrics/classification_performance/quality_by_feature_table.py
@@ -25,6 +25,7 @@ from evidently.legacy.metric_results import StatsByFeature
 from evidently.legacy.model.widget import AdditionalGraphInfo
 from evidently.legacy.model.widget import BaseWidgetInfo
 from evidently.legacy.options.base import AnyOptions
+from evidently.legacy.pipeline.column_mapping import TargetNames
 from evidently.legacy.renderers.base_renderer import MetricRenderer
 from evidently.legacy.renderers.base_renderer import default_renderer
 from evidently.legacy.renderers.html_widgets import header_text
@@ -47,6 +48,7 @@ class ClassificationQualityByFeatureTableResults(MetricResult):
 
     target_name: str
     columns: List[str]
+    target_names: Optional[TargetNames] = None
 
 
 class ClassificationQualityByFeatureTable(UsesRawDataMixin, Metric[ClassificationQualityByFeatureTableResults]):
@@ -173,11 +175,20 @@ class ClassificationQualityByFeatureTable(UsesRawDataMixin, Metric[Classificatio
             reference=reference,
             columns=columns,
             target_name=target_name,
+            target_names=dataset_columns.target_names,
         )
 
 
 @default_renderer(wrap_type=ClassificationQualityByFeatureTable)
 class ClassificationQualityByFeatureTableRenderer(MetricRenderer):
+    @staticmethod
+    def _resolve_target_name(label, target_names: Optional[TargetNames]) -> str:
+        if target_names is not None and isinstance(target_names, dict):
+            resolved = target_names.get(label) or target_names.get(int(label)) if isinstance(label, str) else target_names.get(label)  # type: ignore[arg-type]
+            if resolved is not None:
+                return str(resolved)
+        return str(label)
+
     def render_html(self, obj: ClassificationQualityByFeatureTable) -> List[BaseWidgetInfo]:
         if not obj.get_options().render_options.raw_data:
             return []
@@ -185,6 +196,7 @@ class ClassificationQualityByFeatureTableRenderer(MetricRenderer):
         current_data = result.current.plot_data
         reference_data = result.reference.plot_data if result.reference is not None else None
         target_name = result.target_name
+        target_names = result.target_names
         curr_predictions = result.current.predictions
         # todo: better typing?
         assert curr_predictions is not None
@@ -211,7 +223,13 @@ class ClassificationQualityByFeatureTableRenderer(MetricRenderer):
                 {
                     "details": {
                         "parts": [{"title": "All", "id": "All" + "_" + str(feature_name)}]
-                        + [{"title": str(label), "id": feature_name + "_" + str(label)} for label in labels],
+                        + [
+                            {
+                                "title": self._resolve_target_name(label, target_names),
+                                "id": feature_name + "_" + str(label),
+                            }
+                            for label in labels
+                        ],
                         "insights": [],
                     },
                     "f1": feature_name,
@@ -276,6 +294,7 @@ class ClassificationQualityByFeatureTableRenderer(MetricRenderer):
                     cols = 1
                     subplot_titles = [""]
                 for label in labels:
+                    display_label = self._resolve_target_name(label, target_names)
                     fig = make_subplots(
                         rows=1,
                         cols=cols,
@@ -289,8 +308,8 @@ class ClassificationQualityByFeatureTableRenderer(MetricRenderer):
                             x=current_data[current_data[target_name] == label][feature_name],
                             y=current_data[current_data[target_name] == label][label],
                             mode="markers",
-                            name=str(label),
-                            legendgroup=str(label),
+                            name=display_label,
+                            legendgroup=display_label,
                             marker=dict(
                                 size=6,
                                 # set color equal to a variable
@@ -327,8 +346,8 @@ class ClassificationQualityByFeatureTableRenderer(MetricRenderer):
                                 x=reference_data[reference_data[target_name] == label][feature_name],
                                 y=reference_data[reference_data[target_name] == label][label],
                                 mode="markers",
-                                name=str(label),
-                                legendgroup=str(label),
+                                name=display_label,
+                                legendgroup=display_label,
                                 showlegend=False,
                                 marker=dict(size=6, color=color_options.get_current_data_color()),
                             ),


### PR DESCRIPTION
Fixes #578

When `target_names` is specified in `column_mapping` as a dict mapping raw class values to human-readable names, three classification metric renderers were ignoring it and displaying raw class values. This PR adds `target_names` support to:

- **ClassificationClassSeparationPlot** — tab names now use display names
- **ClassificationProbDistribution** — distribution plot titles and legend labels now use display names
- **ClassificationQualityByFeatureTable** — tab titles and scatter plot trace names now use display names

The existing `ClassificationQualityByClass` metric already supported `target_names` — the same pattern is applied here.

**Changes:**
- Added `target_names: Optional[TargetNames]` field to each result class (defaults to `None` for backward compatibility)
- Passed `dataset_columns.target_names` through the calculate → result → renderer pipeline
- Added a `_resolve_target_name()` helper that maps raw labels to display names when a dict mapping is provided