### PR TITLE
fix: handle empty contingency table in Cramér's V calculation

### DIFF
--- a/src/evidently/legacy/calculations/data_quality.py
+++ b/src/evidently/legacy/calculations/data_quality.py
@@ -335,6 +335,8 @@ def _cramer_v(x: pd.Series, y: pd.Series) -> float:
         Value of the Cramér's V
     """
     arr = pd.crosstab(x, y).values
+    if arr.size == 0:
+        return np.nan
     chi2_stat = chi2_contingency(arr, correction=False)
     phi2 = chi2_stat[0] / arr.sum()
     n_rows, n_cols = arr.shape


### PR DESCRIPTION
## Summary
Fixes #979.

**Root cause:** `_cramer_v()` calls `pd.crosstab(x, y)` which returns an empty array when columns are mutually exclusive (e.g., column A is null whenever column B has a value and vice versa). `chi2_contingency()` raises `ValueError: No data; 'observed' has size 0` on this empty input.

**Fix:** Added an early return of `np.nan` when `arr.size == 0`, before calling `chi2_contingency()`.

## Changes
- `src/evidently/legacy/calculations/data_quality.py`: Added `if arr.size == 0: return np.nan` guard in `_cramer_v()`.

## Testing
- Verified fix prevents ValueError for mutually exclusive categorical columns
- Returns `np.nan` (consistent with the existing `min(n_cols - 1, n_rows - 1) == 0` case)