### PR TITLE
fix: handle pd.NA in convert_types label validation

### DIFF
--- a/src/evidently/core/metric_types.py
+++ b/src/evidently/core/metric_types.py
@@ -564,8 +564,18 @@ def convert_types(val):
         return int(val)
     if isinstance(val, str):
         return val
-    if val is None or np.isnan(val):
-        return val
+    if val is None:
+        return None
+    try:
+        if np.isnan(val):
+            return val
+    except (TypeError, ValueError):
+        pass
+    try:
+        if pd.isna(val):
+            return None
+    except (TypeError, ValueError):
+        pass
     raise ValueError(f"type {type(val)} not supported as Label")
 
 

--- a/tests/future/test_metric_types.py
+++ b/tests/future/test_metric_types.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from evidently.core.metric_types import ByLabelCountValue
 from evidently.core.metric_types import SingleValue
+from evidently.core.metric_types import convert_types
 
 
 @pytest.mark.parametrize(
@@ -20,3 +22,33 @@ def test_by_label_count_value(input: dict, output: tuple):
         tests=[],
     )
     assert {"counts": output[0], "shares": output[1]} == value.to_simple_dict()
+
+
+def test_by_label_count_value_pd_na():
+    value = ByLabelCountValue(
+        counts={pd.NA: SingleValue(value=1.0, display_name="test", metric_value_location=None)},
+        shares={pd.NA: SingleValue(value=1.0, display_name="test", metric_value_location=None)},
+        display_name="test",
+        metric_value_location=None,
+        tests=[],
+    )
+    result = value.to_simple_dict()
+    assert None in result["counts"]
+    assert result["counts"][None] == 1.0
+
+
+def test_convert_types_pd_na():
+    assert convert_types(pd.NA) is None
+
+
+def test_convert_types_pd_nat():
+    assert convert_types(pd.NaT) is None
+
+
+def test_convert_types_none():
+    assert convert_types(None) is None
+
+
+def test_convert_types_preserves_np_nan():
+    result = convert_types(np.nan)
+    assert np.isnan(result)


### PR DESCRIPTION
## Summary
Fixes #1616, fixes #1844.

**Root cause:** `convert_types()` calls `np.isnan(val)` without a type guard. `pd.NA` doesn't support `isnan`, so it raises `TypeError` which surfaces as a pydantic `ValidationError` when building `ByLabelCountValue`.

**Fix:** Split the `None`/`nan` check into separate branches. `np.isnan` is wrapped in try/except for types that don't support it, and `pd.isna` catches pandas-native missing values (`pd.NA`, `pd.NaT`) as a fallback.

## Changes
- `src/evidently/core/metric_types.py`: guard `np.isnan` with try/except, add `pd.isna` fallback for pandas NA types
- `tests/future/test_metric_types.py`: tests for `pd.NA`, `pd.NaT`, `None`, and `np.nan` label conversion

## Testing
- Added test for `pd.NA` as label key in `ByLabelCountValue`
- Added unit tests for `convert_types` with `pd.NA`, `pd.NaT`, `None`, and `np.nan`