### PR TITLE
`fix(report): add helpful migration errors for save_html/save_json/json in 0.7+`

### DIFF
--- a/src/evidently/core/report.py
+++ b/src/evidently/core/report.py
@@ -901,6 +901,44 @@ class Report:
             self.set_dataset_id(dataset_id)
         self.include_tests = include_tests
 
+# -----------------------------------------------------------------------
+    # Migration helpers: raise clear errors for methods that moved to Snapshot
+    # in Evidently 0.7+. Fixes: https://github.com/evidentlyai/evidently/issues/1595
+    # -----------------------------------------------------------------------
+
+    def save_html(self, filename: str) -> None:
+        raise AttributeError(
+            "\n\n`save_html` is not available on the `Report` object in Evidently >= 0.7.\n\n"
+            "In Evidently 0.7+, `report.run()` returns a `Snapshot` object.\n"
+            "Call `save_html` on that snapshot instead:\n\n"
+            "    snapshot = report.run(current_data, reference_data)\n"
+            "    snapshot.save_html('file.html')\n\n"
+            "To use the old API, pin: pip install 'evidently==0.6.7'\n"
+            "Migration guide: https://docs.evidentlyai.com/faq/migration\n"
+        )
+
+    def save_json(self, filename: str) -> None:
+        raise AttributeError(
+            "\n\n`save_json` is not available on the `Report` object in Evidently >= 0.7.\n\n"
+            "In Evidently 0.7+, `report.run()` returns a `Snapshot` object.\n"
+            "Call `save_json` on that snapshot instead:\n\n"
+            "    snapshot = report.run(current_data, reference_data)\n"
+            "    snapshot.save_json('file.json')\n\n"
+            "To use the old API, pin: pip install 'evidently==0.6.7'\n"
+            "Migration guide: https://docs.evidentlyai.com/faq/migration\n"
+        )
+
+    def json(self) -> str:
+        raise AttributeError(
+            "\n\n`.json()` is not available on the `Report` object in Evidently >= 0.7.\n\n"
+            "In Evidently 0.7+, `report.run()` returns a `Snapshot` object.\n"
+            "Call `.json()` on that snapshot instead:\n\n"
+            "    snapshot = report.run(current_data, reference_data)\n"
+            "    snapshot.json()\n\n"
+            "To use the old API, pin: pip install 'evidently==0.6.7'\n"
+            "Migration guide: https://docs.evidentlyai.com/faq/migration\n"
+        )
+        
     def run(
         self,
         current_data: PossibleDatasetTypes,


### PR DESCRIPTION
Fixes #1595

Users on Evidently 0.7+ get a cryptic error with no guidance:

    AttributeError: 'Report' object has no attribute 'save_html'

**Root cause:** In 0.7, `report.run()` returns a `Snapshot` object. 
`save_html`, `save_json`, and `json()` all moved onto `Snapshot`, 
not `Report`.

**Fix:** Added 3 stub methods to the `Report` class that raise clear, 
actionable `AttributeError` messages showing the correct 0.7+ pattern.

After this fix users see:

    AttributeError: `save_html` is not available on the `Report` object 
    in Evidently >= 0.7.

    In Evidently 0.7+, `report.run()` returns a `Snapshot` object.
    Call `save_html` on that snapshot instead:

        snapshot = report.run(current_data, reference_data)
        snapshot.save_html('file.html')

    Migration guide: https://docs.evidentlyai.com/faq/migration