### PR TITLE
Fix `list_projects()` method when using a workspace with an S3 path

### DIFF
--- a/src/evidently/ui/storage/local/base.py
+++ b/src/evidently/ui/storage/local/base.py
@@ -70,7 +70,7 @@ class LocalState:
 
     def list_projects(self) -> List[ProjectID]:
         projects = []
-        for p in self.location.listdir("."):
+        for p in self.location.listdir(""):
             if not UUID_REGEX.match(p):
                 continue
             projects.append(ProjectID(p))


### PR DESCRIPTION
Fix `list_projects()` method when using a workspace with an S3 path. S3 doesn't doesn't interpret `.` as "current directory", but as a different key.

Fixes https://github.com/evidentlyai/evidently/issues/1848