### PR TITLE
Harden workflows against script injection (#1854)

### DIFF
--- a/.github/share-actions/generate-api-reference/action.yml
+++ b/.github/share-actions/generate-api-reference/action.yml
@@ -1,8 +1,21 @@
 name: Generate docs and upload artifact
 inputs:
-  flags:
-    description: 'Flags to pass to the generate.py script'
-    required: true
+  local-source-code:
+    description: 'Whether to generate docs from the locally checked out source code'
+    required: false
+    default: 'false'
+  github-repo:
+    description: 'GitHub repository (owner/name) used for source links in generated docs'
+    required: false
+    default: ''
+  git-revision:
+    description: 'Git revision (branch or tag) used for source links in generated docs'
+    required: false
+    default: ''
+  output-prefix:
+    description: 'Output prefix for generated artifacts'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -12,6 +25,24 @@ runs:
         python-version: "3.11"
 
     - name: Generate documentation
+      env:
+        LOCAL_SOURCE_CODE: ${{ inputs.local-source-code }}
+        GITHUB_REPO: ${{ inputs.github-repo }}
+        GIT_REVISION: ${{ inputs.git-revision }}
+        OUTPUT_PREFIX: ${{ inputs.output-prefix }}
       run: |
-        ./api-reference/generate.py --api-reference-index-href "/evidently/api-reference" ${{ inputs.flags }}
+        args=()
+        if [ "$LOCAL_SOURCE_CODE" = "true" ]; then
+          args+=(--local-source-code)
+        fi
+        if [ -n "$GITHUB_REPO" ]; then
+          args+=(--github-repo "$GITHUB_REPO")
+        fi
+        if [ -n "$GIT_REVISION" ]; then
+          args+=(--git-revision "$GIT_REVISION")
+        fi
+        if [ -n "$OUTPUT_PREFIX" ]; then
+          args+=(--output-prefix "$OUTPUT_PREFIX")
+        fi
+        ./api-reference/generate.py --api-reference-index-href "/evidently/api-reference" "${args[@]}"
       shell: bash

--- a/.github/workflows/deploy-artifacts-to-github-pages.yml
+++ b/.github/workflows/deploy-artifacts-to-github-pages.yml
@@ -66,9 +66,10 @@ jobs:
         id: link
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH_NAME" --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo "$REPOSITORY" --head "$BRANCH_NAME" --json number --jq '.[0].number')
           BRANCH_NAME="${BRANCH_NAME//\//-}"
 
           if [ -n "$PR_NUMBER" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,28 +73,37 @@ jobs:
 
       - name: Run step if evidently_python file(s) change
         if: steps.changed-files.outputs.evidently_python_any_modified == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.evidently_python_all_changed_and_modified_files }}
         run: |
           echo "One or more evidently_python file(s) has changed."
-          echo "List all the files that have changed: ${{ steps.changed-files.outputs.evidently_python_all_changed_and_modified_files }}"
+          echo "List all the files that have changed: $CHANGED_FILES"
 
       - name: Run step if UI file(s) changed
         if: steps.changed-files.outputs.ui_any_modified == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.ui_all_changed_and_modified_files }}
         run: |
           echo "One or more ui file(s) has changed."
-          echo "List all the files that have changed: ${{ steps.changed-files.outputs.ui_all_changed_and_modified_files }}"
+          echo "List all the files that have changed: $CHANGED_FILES"
 
       - name: Run step if API reference file(s) changed
         if: steps.changed-files.outputs.api_reference_any_modified == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.api_reference_all_changed_and_modified_files }}
         run: |
           echo "One or more api reference file(s) has changed."
-          echo "List all the files that have changed: ${{ steps.changed-files.outputs.api_reference_all_changed_and_modified_files }}"
+          echo "List all the files that have changed: $CHANGED_FILES"
 
       - name: Run step if UI service tests need to be run
         if: steps.changed-files.outputs.evidently_python_any_modified == 'true' || steps.changed-files.outputs.ui_build_any_modified == 'true'
+        env:
+          UI_BUILD_FILES: ${{ steps.changed-files.outputs.ui_build_all_changed_and_modified_files }}
+          EVIDENTLY_PYTHON_FILES: ${{ steps.changed-files.outputs.evidently_python_all_changed_and_modified_files }}
         run: |
           echo "UI service tests need to be run."
-          echo "List all the files that have changed: ${{ steps.changed-files.outputs.ui_build_all_changed_and_modified_files }}"
-          echo "List all the files that have changed: ${{ steps.changed-files.outputs.evidently_python_all_changed_and_modified_files }}"
+          echo "List all the files that have changed: $UI_BUILD_FILES"
+          echo "List all the files that have changed: $EVIDENTLY_PYTHON_FILES"
 
   linter:
     # The type of runner that the job will run on
@@ -168,11 +177,12 @@ jobs:
         run: pip install -e .[dev,spark,fsspec,llm,sql]
       - name: Run Tests
         shell: bash
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME="${BRANCH_NAME//\//-}"
           python -m pytest --durations=50 \
-            --html="pytest-reports/${{ env.ARTIFACT_PREFIX }}${BRANCH_NAME}/index.html" \
+            --html="pytest-reports/${ARTIFACT_PREFIX}${BRANCH_NAME}/index.html" \
             --self-contained-html
 
       - name: Upload HTML test report
@@ -268,11 +278,10 @@ jobs:
       - name: 📚 Generate and upload API reference
         uses: ./.github/share-actions/generate-api-reference
         with:
-          flags: >-
-            --local-source-code
-            --github-repo ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-            --git-revision ${{ github.event.pull_request.head.ref || github.ref_name }}
-            --output-prefix '${{ env.ARTIFACT_PREFIX }}'
+          local-source-code: 'true'
+          github-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          git-revision: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          output-prefix: ${{ env.ARTIFACT_PREFIX }}
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v4
@@ -380,10 +389,11 @@ jobs:
       - name: Run Service Playwright tests
         working-directory: ui/service
         shell: bash
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME="${BRANCH_NAME//\//-}"
-          PLAYWRIGHT_HTML_REPORT="playwright-report/${{ env.ARTIFACT_PREFIX }}${BRANCH_NAME}" pnpm test
+          PLAYWRIGHT_HTML_REPORT="playwright-report/${ARTIFACT_PREFIX}${BRANCH_NAME}" pnpm test
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -437,10 +447,11 @@ jobs:
       - name: Run Service Playwright tests
         working-directory: ui/html-visual-testing
         shell: bash
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME="${BRANCH_NAME//\//-}"
-          PLAYWRIGHT_HTML_REPORT="playwright-report/${{ env.ARTIFACT_PREFIX }}${BRANCH_NAME}" pnpm test
+          PLAYWRIGHT_HTML_REPORT="playwright-report/${ARTIFACT_PREFIX}${BRANCH_NAME}" pnpm test
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Check _version.py was updated
         env:
           PYTHONPATH: ./src
+          REF_NAME: ${{ github.ref_name }}
         run: |-
           VERSION_TO_RELEASE=v$(python "./src/evidently/_version.py")
-          if [ "${{ github.ref_name }}" != "$VERSION_TO_RELEASE" ]; then
-            echo "Release triggered for tag ${{ github.ref_name }} but version.py contains $VERSION_TO_RELEASE"
+          if [ "$REF_NAME" != "$VERSION_TO_RELEASE" ]; then
+            echo "Release triggered for tag $REF_NAME but version.py contains $VERSION_TO_RELEASE"
             exit 1
           fi
 
@@ -121,7 +122,7 @@ jobs:
       - name: 📚 Generate and upload API reference
         uses: ./.github/share-actions/generate-api-reference
         with:
-          flags: --git-revision ${{ github.ref_name }}
+          git-revision: ${{ github.ref_name }}
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Addresses the script-injection findings from #1854 (section 1 of the audit). Scoped exactly as discussed in [this comment](https://github.com/evidentlyai/evidently/issues/1854#issuecomment-4291997741) — action pinning will follow in a separate PR. `permissions:` hardening, Zizmor adoption, and the Docker secret handling are left for your internal review as requested.

## Summary

Every `${{ … }}` expression that previously landed directly inside a `run:` block has been moved to a step-level `env:` variable (or, for the composite action, into a structured input). Shell sees environment variables as data — metacharacters inside them can't re-enter the parser.

## Files changed

| File | Sites | Value formerly in shell |
|---|---|---|
| `main.yml` | 6 | `github.event.pull_request.head.ref` (×3), `steps.changed-files.outputs.*_all_changed_and_modified_files` (×5 expressions across 4 steps), `github.event.pull_request.head.repo.full_name`, `env.ARTIFACT_PREFIX` (now used as plain `$ARTIFACT_PREFIX` since it's a workflow-level env var) |
| `deploy-artifacts-to-github-pages.yml` | 1 | `github.event.workflow_run.head_branch`, `github.repository` |
| `share-actions/generate-api-reference/action.yml` | 1 (refactor) | See below |
| `release.yml` | 2 | Updated call site for composite action; also moved `github.ref_name` out of the version-check shell (see note) |

### Composite action refactor

`generate-api-reference/action.yml` previously accepted a single free-form `flags` string and expanded it with `${{ inputs.flags }}` inside a `run:` block — which meant any unsafe value in the caller's flags string (e.g., a branch name) hit the shell as tokens, not data. Refactored to four typed inputs (`local-source-code`, `github-repo`, `git-revision`, `output-prefix`), with argv built via a bash array so values are passed as single quoted arguments. Both callers (`main.yml` and `release.yml`) updated.

### One extra fix beyond the original audit

While working on `release.yml` I noticed that the version-check step (`main.yml` → sorry, `release.yml` lines 20-28) interpolated `github.ref_name` directly into the shell. Git tag names can legally contain `"` among other characters, so a tag like `v1.0"; rm -rf /; echo "` could escape the quotes and execute. Same class of issue as the rest of section 1, so I included it here — happy to split out if you'd rather keep this PR strictly to the audit list.

## What's explicitly left for later

- **Pinning actions to stable versions** — separate PR, per the comment thread.
- **`permissions: read-all`** — not touched.
- **`tj-actions/changed-files@v42`** — not touched in this PR (pinning PR will address).
- **`docker.yml` secret handling** — deferred to internal review as requested.
- **Zizmor adoption** — deferred to internal discussion as requested.

## Test plan

- [ ] CI on this PR should exercise `main.yml` end-to-end (the changed-files job, linter, tests, UI builds, API reference generation, Playwright runs).
- [ ] `release.yml` is tag-triggered so can't be directly exercised from a PR — logic-preserving refactor only (env-var rename; no control-flow change).
- [ ] `deploy-artifacts-to-github-pages.yml` runs on `workflow_run` after CI completes; behavior preserved (env-var move only).