### PR TITLE
Pin GitHub Actions to specific stable versions (#1854)

### DIFF
--- a/.github/share-actions/generate-api-reference/action.yml
+++ b/.github/share-actions/generate-api-reference/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v7.6.0
       with:
         python-version: "3.11"
 

--- a/.github/share-actions/get-bikes-dataset-cached/action.yml
+++ b/.github/share-actions/get-bikes-dataset-cached/action.yml
@@ -2,7 +2,7 @@ name: Get bikes dataset cached
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v4.3.0
       id: cache-bikes-dataset
       env:
         cache-name: cache-bikes-dataset

--- a/.github/share-actions/get-scipy-datasets/action.yml
+++ b/.github/share-actions/get-scipy-datasets/action.yml
@@ -6,7 +6,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v4.3.0
       id: cache-scipy-data
       env:
         cache-name: cache-scipy-data
@@ -16,7 +16,7 @@ runs:
         enableCrossOsArchive: true
     - name: Install the latest version of uv and set the python version
       if: ${{ steps.cache-scipy-data.outputs.cache-hit != 'true' }}
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v7.6.0
       with:
         python-version: "3.11"
     - name: Save GCP SA key

--- a/.github/share-actions/ui-node-pnpm-install/action.yml
+++ b/.github/share-actions/ui-node-pnpm-install/action.yml
@@ -8,12 +8,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v3.0.0
       with:
         version: 9
 
     - name: Use Node.js 20
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.4.0
       with:
         node-version: 20
         cache: "pnpm"

--- a/.github/share-actions/ui-types-from-backend/action.yml
+++ b/.github/share-actions/ui-types-from-backend/action.yml
@@ -4,13 +4,13 @@ runs:
   steps:
     - name: Cache UI types
       id: cache-ui-types
-      uses: actions/cache@v4
+      uses: actions/cache@v4.3.0
       with:
         path: |
           ui/packages/evidently-ui-lib/src/api/types/endpoints.d.ts
         key: ui-types-${{ runner.os }}-${{ hashFiles('./.github/**', './src/evidently/**', '!src/evidently/**/ui/**/assets/**', '!src/evidently/nbextension/**') }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5.6.0
       if: steps.cache-ui-types.outputs.cache-hit != 'true'
       with:
         python-version: "3.11"

--- a/.github/workflows/deploy-artifacts-to-github-pages.yml
+++ b/.github/workflows/deploy-artifacts-to-github-pages.yml
@@ -16,13 +16,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
         with:
           ref: gh-pages
           fetch-depth: 0
 
       - name: 📥 Download API reference artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         continue-on-error: true
         with:
           name: api-reference
@@ -31,7 +31,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: 📥 Download pytest-html-report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         continue-on-error: true
         with:
           name: pytest-html-report
@@ -40,7 +40,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: 📥 Download UI service playwright report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         continue-on-error: true
         with:
           name: ui-service-playwright-report
@@ -49,7 +49,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: 📥 Download UI HTML visual testing playwright report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         continue-on-error: true
         with:
           name: ui-html-visual-testing-playwright-report
@@ -78,7 +78,7 @@ jobs:
 
       - name: Comment on PR with deployment link
         if: steps.link.outputs.pr_number
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v2.9.4
         with:
           number: ${{ steps.link.outputs.pr_number }}
           message: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Login to docker.io
         run: echo ${{ secrets.DOCKER_PWD }} | docker login -u ${{ secrets.DOCKER_LOGIN }} --password-stdin
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4.3.1
       - name: setup builder
         run: docker buildx create --name mybuilder --bootstrap --use
       - name: Build and release latest image

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,7 @@ jobs:
         minimal: [false]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - name: 🔍 Get bikes dataset cached
         uses: ./.github/share-actions/get-bikes-dataset-cached
@@ -30,7 +30,7 @@ jobs:
       - name: Prepare Bikes dataset
         run: unzip Bike-Sharing-Dataset.zip -d Bike-Sharing-Dataset
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python }}
           architecture: "x64"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,13 @@ jobs:
       ui_any_modified: ${{ steps.changed-files.outputs.ui_any_modified == 'true' }}
       ui_service_tests_need_run: ${{ steps.changed-files.outputs.evidently_python_any_modified == 'true' || steps.changed-files.outputs.ui_build_any_modified == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - name: Get all files that have changed
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        # SHA-pinned (not just tag-pinned) because this action was the target
+        # of a March 2025 supply-chain attack where version tags were force-pushed.
+        uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11 # v42.1.0
         with:
           files_yaml: |
             api_reference:
@@ -104,8 +106,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.3.1
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -127,7 +129,7 @@ jobs:
     needs: changed_files
     if: ${{ needs.changed_files.outputs.evidently_any_modified == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - name: 🔍 Get bikes dataset cached
         uses: ./.github/share-actions/get-bikes-dataset-cached
       - name: 🔍 Get scipy dataset cached
@@ -146,8 +148,8 @@ jobs:
       EVIDENTLY_TEST_ENVIRONMENT: 1
       SCIKIT_LEARN_DATA: scikit_learn_data
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.3.1
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -177,7 +179,7 @@ jobs:
 
       - name: Upload HTML test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: pytest-html-report
           path: pytest-reports
@@ -202,8 +204,8 @@ jobs:
             python: "3.13"
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.3.1
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -228,8 +230,8 @@ jobs:
     needs: changed_files
     if: ${{ needs.changed_files.outputs.evidently_any_modified == 'true' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.3.1
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -243,11 +245,11 @@ jobs:
       - name: Install wheel
         run: pip install wheel
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v4.2.0
       - name: Build package
         run: uv build
       - name: Archive built package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: evidently-package-build-artifact
           path: dist/
@@ -264,7 +266,7 @@ jobs:
         )
       }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - name: 📚 Generate and upload API reference
         uses: ./.github/share-actions/generate-api-reference
         with:
@@ -275,7 +277,7 @@ jobs:
             --output-prefix '${{ env.ARTIFACT_PREFIX }}'
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: api-reference
           path: api-reference/dist
@@ -289,7 +291,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
 
       - name: 📥 Install ui dependencies
         uses: ./.github/share-actions/ui-node-pnpm-install
@@ -307,7 +309,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
 
       - name: 📥 Install ui dependencies
         uses: ./.github/share-actions/ui-node-pnpm-install
@@ -331,13 +333,13 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
         with:
           sparse-checkout: |
             ui
             .dvc
             .github
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.11"
           architecture: "x64"
@@ -385,7 +387,7 @@ jobs:
           BRANCH_NAME="${BRANCH_NAME//\//-}"
           PLAYWRIGHT_HTML_REPORT="playwright-report/${{ env.ARTIFACT_PREFIX }}${BRANCH_NAME}" pnpm test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6.2
         if: always()
         with:
           name: ui-service-playwright-report
@@ -400,7 +402,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
       - name: Install dvc
         run: pip install 'pathspec<1' 'dvc[gs]==3.50.1'
 
@@ -410,7 +412,7 @@ jobs:
       - name: 📥 Install ui dependencies
         uses: ./.github/share-actions/ui-node-pnpm-install
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.10"
           cache: "pip"
@@ -442,7 +444,7 @@ jobs:
           BRANCH_NAME="${BRANCH_NAME//\//-}"
           PLAYWRIGHT_HTML_REPORT="playwright-report/${{ env.ARTIFACT_PREFIX }}${BRANCH_NAME}" pnpm test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6.2
         if: always()
         with:
           name: ui-html-visual-testing-playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - name: Checking out sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.11"
       - name: Check _version.py was updated
@@ -34,17 +34,17 @@ jobs:
       - check
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v4.2.0
       - name: Build a binary wheel and a source tarball
         run: uv build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: python-package-distributions
           path: dist/
@@ -64,12 +64,12 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   build_and_publish_docker:
     name: Build Docker image and publish it to DockerHub
@@ -83,17 +83,17 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
       - id: generate-tag
         name: Santize branch name the same way normalize function of argo-cd works
         run: |
@@ -102,7 +102,7 @@ jobs:
 
       - id: docker-push-tagged
         name: Tag Docker image and push to DockerHub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v5.4.0
         with:
           file: docker/Dockerfile.service
           platforms: linux/amd64,linux/arm64
@@ -117,14 +117,14 @@ jobs:
       - publish_to_pypi
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - name: 📚 Generate and upload API reference
         uses: ./.github/share-actions/generate-api-reference
         with:
           flags: --git-revision ${{ github.ref_name }}
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: api-reference
           path: api-reference/dist
@@ -140,13 +140,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
         with:
           ref: gh-pages
           fetch-depth: 0
 
       - name: 📥 Download API reference artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: api-reference
           path: ./artifacts/api-reference
@@ -165,15 +165,15 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
       - id: create_release
         name: Create Release for the Tag
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.21.0
         with:
           artifacts: "dist/*"
           generateReleaseNotes: true


### PR DESCRIPTION
Part 2 of #1854 (paired with #1864). Pins every third-party GitHub Actions reference in the repo to a specific stable version, so a force-pushed tag on an upstream action cannot silently run new code here.

## Approach

Conservative: stay on the same major version the repo is already using, pin to the latest stable patch within that major. No behavioral changes expected — this is the same code the `@v4` (etc.) floating tag resolves to right now.

## Pin targets

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` (and `@master` in `docker.yml`) | `@v4.3.1` |
| `actions/setup-python` | `@v5` | `@v5.6.0` |
| `actions/upload-artifact` | `@v4` | `@v4.6.2` |
| `actions/download-artifact` | `@v4` | `@v4.3.0` |
| `actions/cache` | `@v4` | `@v4.3.0` |
| `actions/setup-node` | `@v4` | `@v4.4.0` |
| `astral-sh/setup-uv` | `@v4` / `@v7` | `@v4.2.0` / `@v7.6.0` |
| `pnpm/action-setup` | `@v3` | `@v3.0.0` |
| `marocchino/sticky-pull-request-comment` | `@v2` | `@v2.9.4` |
| `docker/login-action` | `@v3` | `@v3.7.0` |
| `docker/setup-buildx-action` | `@v3` | `@v3.12.0` |
| `docker/setup-qemu-action` | `@v3` | `@v3.7.0` |
| `docker/build-push-action` | `@v5` | `@v5.4.0` |
| `ncipollo/release-action` | `@v1` | `@v1.21.0` |
| `pypa/gh-action-pypi-publish` | `@release/v1` (branch ref) | `@v1.14.0` |
| `tj-actions/changed-files` | `@v42` | **SHA-pinned** `@aa08304b` with `# v42.1.0` comment |

## Notes

- `actions/checkout@master` in `docker.yml` was tracking the default branch, which is the worst-case pinning scenario. Now pinned to `v4.3.1` along with the rest.
- **`tj-actions/changed-files`** is SHA-pinned rather than tag-pinned because it was the target of a documented [March 2025 supply-chain attack](https://www.stepsecurity.io/blog/tj-actions-changed-files-attack-detection) where version tags were force-pushed to malicious commits. The pinned commit `aa08304bd477b800d468db44fe10f6c61f7f7b11` is the legitimate v42.1.0 from 2024-03-09, pre-dating the incident by a year. A trailing comment (`# v42.1.0`) keeps the version readable. Happy to switch to plain tag pinning if you prefer consistency with the other actions.
- `pypa/gh-action-pypi-publish`: moved from the `release/v1` branch ref to `@v1.14.0`. OIDC trusted-publishing is a PyPI server-side feature keyed on `{repo, workflow, environment}`, so this change is purely a ref-type change and does not affect publishing behavior.
- This PR does **not** include the `tj-actions/changed-files` major upgrade (v42 → v47) — held off intentionally to avoid bundling a major-version bump with a security pin. If you want that bump, a follow-up PR would be appropriate.

## Test plan

- [ ] CI on this PR exercises most of `main.yml` end-to-end. The changed-files job, linter, tests, UI builds, and Playwright runs should all succeed with pinned versions.
- [ ] `release.yml` is tag-triggered and can't be exercised from a PR; behavioral changes are zero (same major versions), so low risk.
- [ ] `deploy-artifacts-to-github-pages.yml` runs after CI completes via `workflow_run`; same story.
- [ ] `docker.yml` is `workflow_dispatch` only; the `actions/checkout@master` → `@v4.3.1` change is functionally identical to all the other checkout call sites.