### PR TITLE
fix: PromptOptimizer inherits LLM provider/model from executor's judge when not explicitly set

### DIFF
--- a/src/evidently/llm/optimization/optimizer.py
+++ b/src/evidently/llm/optimization/optimizer.py
@@ -364,10 +364,10 @@ class OptimizerConfig(AutoAliasMixin, EvidentlyBaseModel):
     class Config:
         is_base_type = True
 
-    provider: str = "openai"
-    """LLM provider name."""
-    model: str = "gpt-4o-mini"
-    """LLM model name."""
+    provider: Optional[str] = None
+    """LLM provider name. When None, inherited from the executor's judge if available."""
+    model: Optional[str] = None
+    """LLM model name. When None, inherited from the executor's judge if available."""
     verbose: bool = False
     """Whether to print optimization progress."""
     seed: Optional[int] = None
@@ -586,14 +586,38 @@ class OptimizerContext(BaseModel):
             self.runs.append(run)
             return run
 
+    def resolve_provider_model(self) -> Tuple[str, str]:
+        """Resolve the effective LLM provider and model for this context.
+
+        When provider or model are not set on the config, falls back to the
+        provider/model of the executor's judge (if it has one). This lets
+        PromptOptimizer inherit the provider used by an LLMJudge-based executor
+        without requiring the user to duplicate that configuration.
+
+        Returns:
+        * Tuple of (provider, model) as concrete strings.
+        """
+        provider = self.config.provider
+        model = self.config.model
+        if provider is None or model is None:
+            executor = self.params.get(Params.Executor)
+            if executor is not None and hasattr(executor, "judge"):
+                judge = executor.judge
+                if provider is None and hasattr(judge, "provider"):
+                    provider = judge.provider
+                if model is None and hasattr(judge, "model"):
+                    model = judge.model
+        return provider or "openai", model or "gpt-4o-mini"
+
     @property
     def llm_wrapper(self) -> LLMWrapper:
         """Get the LLM wrapper for this context.
 
         Returns:
-        * `LLMWrapper` configured with the context's provider and model.
+        * `LLMWrapper` configured with the resolved provider and model.
         """
-        return get_llm_wrapper(self.config.provider, self.config.model, self.params[Params.Options])
+        provider, model = self.resolve_provider_model()
+        return get_llm_wrapper(provider, model, self.params[Params.Options])
 
     @property
     def options(self) -> Options:

--- a/src/evidently/llm/optimization/prompts.py
+++ b/src/evidently/llm/optimization/prompts.py
@@ -563,8 +563,12 @@ class BlankLLMJudge(PromptExecutor):
             raise OptimizationConfigurationError("Target is required for BlankLLMJudge executor")
         inputs = dataset.input_values
         labels = target.unique()
-        model = context.config.model
-        provider = context.config.provider
+        if context.config.provider is None or context.config.model is None:
+            raise OptimizationConfigurationError(
+                "BlankLLMJudge requires provider and model to be set on the optimizer. "
+                "Pass provider=... and model=... to PromptOptimizer()."
+            )
+        provider, model = context.resolve_provider_model()
         if len(labels) < 2:
             raise OptimizationConfigurationError(f"Cannot create judge, target column has {len(labels)} labels")
         if len(labels) == 2:

--- a/tests/future/llm/test_optimizer.py
+++ b/tests/future/llm/test_optimizer.py
@@ -5,6 +5,7 @@ import pytest
 from evidently.llm.optimization.optimizer import OptimizationConfigurationError
 from evidently.llm.optimization.optimizer import OptimizerConfig
 from evidently.llm.optimization.optimizer import OptimizerContext
+from evidently.llm.optimization.optimizer import Params
 
 
 def test_optimizer_context_set_get_param():
@@ -44,3 +45,48 @@ async def test_optimizer_context_add_log_and_get_log():
     assert run.get_log("logid") == log
     with pytest.raises(KeyError):
         run.get_log("notfound")
+
+
+def test_resolve_provider_model_from_config():
+    """Explicit provider/model on config are returned as-is."""
+    ctx = OptimizerContext(
+        config=OptimizerConfig(provider="anthropic", model="claude-3-haiku"),
+        params={Params.Options: MagicMock()},
+        runs=[],
+    )
+    ctx.locked = True
+    provider, model = ctx.resolve_provider_model()
+    assert provider == "anthropic"
+    assert model == "claude-3-haiku"
+
+
+def test_resolve_provider_model_inherits_from_executor_judge():
+    """When config has no provider/model, they are inherited from the executor's judge."""
+    mock_judge = MagicMock()
+    mock_judge.provider = "vertex_ai"
+    mock_judge.model = "gemini-2.5-flash"
+    mock_executor = MagicMock()
+    mock_executor.judge = mock_judge
+
+    ctx = OptimizerContext(
+        config=OptimizerConfig(),
+        params={Params.Options: MagicMock(), Params.Executor: mock_executor},
+        runs=[],
+    )
+    ctx.locked = True
+    provider, model = ctx.resolve_provider_model()
+    assert provider == "vertex_ai"
+    assert model == "gemini-2.5-flash"
+
+
+def test_resolve_provider_model_falls_back_to_openai():
+    """With no config and no executor judge, defaults to openai/gpt-4o-mini."""
+    ctx = OptimizerContext(
+        config=OptimizerConfig(),
+        params={Params.Options: MagicMock()},
+        runs=[],
+    )
+    ctx.locked = True
+    provider, model = ctx.resolve_provider_model()
+    assert provider == "openai"
+    assert model == "gpt-4o-mini"


### PR DESCRIPTION
Fixes #1856.

When `PromptOptimizer` runs its internal optimization step (e.g. `FeedbackStrategy` calling `SimplePromptOptimizer` to generate an improved prompt), it calls `context.llm_wrapper`. That wrapper was always built from `OptimizerConfig.provider` and `OptimizerConfig.model`, which hardcoded defaults of `"openai"` / `"gpt-4o-mini"`. So any user whose judge used a non-OpenAI provider (e.g. Vertex AI) hit:

```
OpenAIError: The api_key client option must be set either by passing api_key to the client
or by setting the OPENAI_API_KEY environment variable
```

even though they never configured OpenAI anywhere.

**Root cause**: `OptimizerConfig.provider` and `model` defaulted to hardcoded OpenAI strings, so the optimizer always used OpenAI for its own completions regardless of what the user's executor was doing.

**Fix**:

- `OptimizerConfig.provider` and `model` now default to `None` instead of `"openai"` / `"gpt-4o-mini"`.
- `OptimizerContext` gains `resolve_provider_model()` which checks the executor's judge for `provider`/`model` when the config fields are `None`, then falls back to `"openai"` / `"gpt-4o-mini"` for backward compatibility.
- `llm_wrapper` uses `resolve_provider_model()` rather than reading config directly.
- `BlankLLMJudge._build_judge()` raises a clear `OptimizationConfigurationError` when provider/model are not set (it cannot inherit from an executor since it is the executor creating the sub-judge; users must pass `provider=` and `model=` to `PromptOptimizer()` explicitly).

**Before** (broken):

```python
optimizer = PromptOptimizer("run", strategy="feedback")
await optimizer.arun(executor=judge_with_vertex_ai, ...)
# → OpenAIError even though no OpenAI configured
```

**After** (fixed):

```python
optimizer = PromptOptimizer("run", strategy="feedback")
await optimizer.arun(executor=judge_with_vertex_ai, ...)
# → uses vertex_ai/gemini-2.5-flash for both evaluation and optimization
```

Users who want a different provider for the optimizer than their judge can still pass `provider=` and `model=` explicitly to `PromptOptimizer()`.

Three new unit tests cover the three paths (explicit config, inherited from judge, default fallback).