### PR TITLE
fix(stattests): replace deprecated np.percentile interpolation kwarg (NumPy 2.4 compat)

### DIFF
--- a/src/evidently/legacy/calculations/stattests/mmd_stattest.py
+++ b/src/evidently/legacy/calculations/stattests/mmd_stattest.py
@@ -33,16 +33,14 @@ def sigma_median(dist: np.ndarray) -> float:
     sigma = (
         0.5
         * np.percentile(
-            # error: No overload variant of "percentile" matches argument types
-            # "ndarray[Any, Any]", "int", "str"  [call-overload]
             a=dist.flatten(),
             q=50,
-            interpolation="nearest",  # type: ignore[call-overload]
+            method="nearest",
         )
     ) ** 0.5
     if sigma == 0:
         return (0.5 * 1) ** 0.5
-    return sigma
+    return float(sigma)
 
 
 def rbf(x: np.ndarray, y: np.ndarray, pass_sigma: Optional[float]) -> Tuple[np.ndarray, float]:

--- a/tests/stattests/test_stattests.py
+++ b/tests/stattests/test_stattests.py
@@ -15,6 +15,7 @@ from evidently.legacy.calculations.stattests.g_stattest import g_test
 from evidently.legacy.calculations.stattests.hellinger_distance import hellinger_stat_test
 from evidently.legacy.calculations.stattests.mann_whitney_urank_stattest import mann_whitney_u_stat_test
 from evidently.legacy.calculations.stattests.mmd_stattest import empirical_mmd
+from evidently.legacy.calculations.stattests.mmd_stattest import sigma_median
 from evidently.legacy.calculations.stattests.t_test import t_test
 from evidently.legacy.calculations.stattests.tvd_stattest import tvd_test
 from evidently.legacy.core import ColumnType
@@ -119,6 +120,14 @@ def test_cramer_von_mises() -> None:
     reference = pd.Series(stats.norm.rvs(size=100, random_state=0))
     current = pd.Series(stats.norm.rvs(size=100, random_state=1))
     assert cramer_von_mises.func(reference, current, "num", 0.001) == (approx(0.8076839, abs=1e-3), False)
+
+
+def test_sigma_median_numpy_compat() -> None:
+    # np.percentile dropped the 'interpolation' kwarg in NumPy 2.4 (replaced by 'method').
+    # This test ensures sigma_median does not raise TypeError on NumPy >= 2.4.
+    dist = np.array([[0.0, 1.0, 4.0], [1.0, 0.0, 1.0], [4.0, 1.0, 0.0]])
+    result = sigma_median(dist)
+    assert result == approx((0.5 * 1.0) ** 0.5, abs=1e-9)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Fixes #1858.

`np.percentile`'s `interpolation` keyword was deprecated in NumPy 1.22 and **removed in NumPy 2.4.0**, causing a `TypeError` whenever `empirical_mmd` drift detection is used on NumPy ≥ 2.4:

```
TypeError: percentile() got an unexpected keyword argument 'interpolation'
```

## Changes

- `src/evidently/legacy/calculations/stattests/mmd_stattest.py` — replace `interpolation="nearest"` with `method="nearest"` (the replacement introduced in NumPy 1.22), remove the now-unnecessary `# type: ignore[call-overload]` comment, and cast the return value to `float` to match the declared return type.
- `tests/stattests/test_stattests.py` — add `test_sigma_median_numpy_compat` which calls `sigma_median` directly, ensuring it does not raise `TypeError` on NumPy ≥ 2.4.

## Testing

```
pytest tests/stattests/test_stattests.py -k "mmd or sigma_median"
# 7 passed
```