### PR TITLE
fix(stattests): honor n_bins in get_binned_data for numeric features (#1400)

### DIFF
--- a/src/evidently/legacy/calculations/stattests/utils.py
+++ b/src/evidently/legacy/calculations/stattests/utils.py
@@ -21,7 +21,7 @@ def get_binned_data(
         reference_data: reference data
         current_data: current data
         feature_type: feature type
-        n: number of quantiles
+        n: number of bins for numeric features (issue #1400)
     Returns:
         reference_percents: % of records in each bucket for reference
         current_percents: % of records in each bucket for current
@@ -30,7 +30,11 @@ def get_binned_data(
 
     if feature_type == ColumnType.Numerical and n_vals > 20:
         combined = np.asarray(pd.concat([reference_data, current_data], axis=0).values)
-        bins = np.histogram_bin_edges(combined, bins="sturges")
+        # Honor the caller-supplied `n`. Previously the signature declared `n`
+        # but the numeric branch ignored it (always used Sturges' rule), so the
+        # `n_bins` parameter of the PSI / Jensen-Shannon / KL stat tests had no
+        # effect on numeric features. See issue #1400.
+        bins = np.histogram_bin_edges(combined, bins=n)
         reference_percents = np.histogram(reference_data, bins)[0] / len(reference_data)
         current_percents = np.histogram(current_data, bins)[0] / len(current_data)
 

--- a/tests/calculations/stattests/test_utils.py
+++ b/tests/calculations/stattests/test_utils.py
@@ -4,8 +4,10 @@ import pytest
 
 from evidently.legacy.calculations.stattests.tvd_stattest import _total_variation_distance
 from evidently.legacy.calculations.stattests.utils import generate_fisher2x2_contingency_table
+from evidently.legacy.calculations.stattests.utils import get_binned_data
 from evidently.legacy.calculations.stattests.utils import get_unique_not_nan_values_list_from_series
 from evidently.legacy.calculations.stattests.utils import permutation_test
+from evidently.legacy.core import ColumnType
 
 
 @pytest.mark.parametrize(
@@ -91,3 +93,18 @@ def test_input_data_length_check_generate_fisher2x2_contingency_table(
         match="reference_data and current_data are not of equal length, please ensure that they are of equal length",
     ):
         generate_fisher2x2_contingency_table(current_data, reference_data)
+
+
+@pytest.mark.parametrize("n", [5, 10, 30, 50])
+def test_get_binned_data_honors_n_for_numeric(n: int) -> None:
+    """Regression test for issue #1400: `n` was silently ignored for numeric
+    features (Sturges' rule was always used). After the fix, the caller's `n`
+    must control the number of bins."""
+    rng = np.random.default_rng(0)
+    # > 20 unique values forces the numeric branch in get_binned_data.
+    reference = pd.Series(rng.normal(size=500))
+    current = pd.Series(rng.normal(size=500))
+    ref_pct, cur_pct = get_binned_data(reference, current, ColumnType.Numerical, n, feel_zeroes=False)
+    # np.histogram_bin_edges with bins=n returns n bins -> percent arrays of length n.
+    assert ref_pct.shape == (n,)
+    assert cur_pct.shape == (n,)


### PR DESCRIPTION
## Summary

Closes #1400.

The numeric branch of `get_binned_data()` in
`src/evidently/legacy/calculations/stattests/utils.py` previously ignored the
caller-supplied `n` parameter and always used Sturges' rule via
`np.histogram_bin_edges(combined, bins=\"sturges\")`. The PSI / Jensen-Shannon /
KL stat tests all pass `n_bins` through to this function, so their `n_bins`
argument was effectively a no-op on numeric features (>20 unique values).

The fix passes `n` through to `np.histogram_bin_edges(bins=n)`. A regression
test (`test_get_binned_data_honors_n_for_numeric`) parametrised on four bin
counts asserts the returned percent arrays have shape `(n,)`. The test fails
on `origin/main` (gets ~11 bins via Sturges for the 5-bin case) and passes on
this branch.

## Reproduce BEFORE/AFTER yourself (copy-paste)

\`\`\`bash
# Run from the repo root in a clean checkout.
git fetch origin && git fetch https://github.com/jbbqqf/evidently.git fix/1400-psi-n-bins:_pr1400

run_check() {
  python - <<'PY'
import numpy as np, pandas as pd
from evidently.legacy.calculations.stattests.utils import get_binned_data
from evidently.legacy.core import ColumnType
rng = np.random.default_rng(0)
ref = pd.Series(rng.normal(size=500))
cur = pd.Series(rng.normal(size=500))
for n in (5, 10, 30, 50):
    r, _ = get_binned_data(ref, cur, ColumnType.Numerical, n, feel_zeroes=False)
    print(f\"requested n={n}, got {len(r)} bins\")
PY
}

# BEFORE — origin/main: n is ignored, Sturges is used.
git checkout origin/main -- src/evidently/legacy/calculations/stattests/utils.py
pip install -q -e . >/dev/null
run_check
# Expected: 'got 11 bins' (or similar) for every requested n.

# AFTER — this branch: n is honored.
git checkout _pr1400 -- src/evidently/legacy/calculations/stattests/utils.py
pip install -q -e . >/dev/null
run_check
# Expected: 'got N bins' matching the requested n in every line.

# Restore.
git checkout origin/main -- src/evidently/legacy/calculations/stattests/utils.py
\`\`\`

## What I ran locally

- \`pytest tests/stattests/ tests/calculations/stattests/ -q\` -> 105 passed
- \`ruff check\` and \`ruff format --check\` on touched files -> clean
- Test \`test_get_binned_data_honors_n_for_numeric\` fails on \`origin/main\`
  with \`assert (11,) == (5,)\`, passes on this branch.

## Edge cases / behavior change to flag for review

| Scenario | Before | After |
|---|---|---|
| Numeric with > 20 unique vals, n_bins=30 (default) | Used Sturges (~10-13 bins) | Uses 30 bins |
| Numeric with <= 20 unique vals | Categorical branch (unchanged) | Same |
| Categorical features | Categorical branch (unchanged) | Same |
| n_bins=5 | Ignored, Sturges used | 5 bins |

This is a **behavior change for numeric features** in PSI / Jensen-Shannon /
KL: users will see different drift values because the bin count now actually
matches what they configured. The previous behavior contradicted the
documented \`n_bins\` parameter and the issue reporter explicitly flagged this
contradiction. I'm flagging it here so a maintainer can decide whether to
ship this as a fix or guard with a deprecation toggle.

## AI disclosure

This pull request was authored with assistance from Anthropic's Claude (an AI
coding assistant) running under my direction. I read the diff and reproduced
the BEFORE/AFTER behavior locally before submitting.