### PR TITLE
fix(deps): bump pandas floor to 2.0 so [parquet] extra is valid (#1700)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
     "plotly>=5.10.0,<6",
     "statsmodels>=0.14.0",
     "scikit-learn>=1.1.1",
-    "pandas[parquet]>=1.3.5",
+    # pandas[parquet] extra was introduced in pandas 2.0 (issue #1700);
+    # earlier versions silently ignore the extra and leave pyarrow uninstalled.
+    "pandas[parquet]>=2.0.0",
     "numpy>=1.23.0",
     "nltk>=3.6.7",
     "scipy>=1.10.0",

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -2,7 +2,7 @@
 plotly==5.10.0
 statsmodels==0.14.0
 scikit-learn==1.1.1
-pandas[parquet]==1.3.5
+pandas[parquet]==2.0.0
 numpy==1.23.0
 nltk==3.6.7
 scipy==1.10.0


### PR DESCRIPTION
## Summary

Closes #1700.

The `pandas[parquet]` extra was introduced in pandas 2.0; on pandas <2 the
extra is unknown and pyarrow is silently not installed, which is the
breakage the issue reports. The earlier fix (99d52ae2) was reverted in
#1804 / #1807 when the pandas upper bound was tweaked, so main currently
declares an invalid combination again:

\`\`\`toml
# pyproject.toml
\"pandas[parquet]>=1.3.5\"
# requirements.min.txt
pandas[parquet]==1.3.5
\`\`\`

Bumping the floor to \`2.0.0\` resolves the conflict cleanly. This matches the
de-facto situation: pandas 1.3.5 has no wheels for cpython 3.10+ and the
project requires python>=3.10 since #1811.

## Reproduce BEFORE/AFTER yourself (copy-paste)

\`\`\`bash
git fetch origin && git fetch https://github.com/jbbqqf/evidently.git fix/1700-pandas-parquet-extra:_pr1700

# BEFORE — origin/main: requirements.min.txt asks for an extra that does not exist on pandas 1.3.5.
git checkout origin/main -- pyproject.toml requirements.min.txt
python -c \"
import urllib.request, json
url='https://pypi.org/pypi/pandas/1.3.5/json'
data=json.load(urllib.request.urlopen(url))
extras=[e for e in (data['info'].get('requires_dist') or []) if 'extra' in e]
parquet=[e for e in extras if 'parquet' in e]
print('pandas 1.3.5 parquet extra:', parquet or 'NONE')
\"
# Expected: 'NONE' (no parquet extra exists in pandas 1.3.5).

# AFTER — this branch: floor is 2.0.0; parquet extra exists from 2.0 onward.
git checkout _pr1700 -- pyproject.toml requirements.min.txt
python -c \"
import urllib.request, json
url='https://pypi.org/pypi/pandas/2.0.0/json'
data=json.load(urllib.request.urlopen(url))
parquet=[e for e in (data['info'].get('requires_dist') or []) if 'parquet' in e]
print('pandas 2.0.0 parquet extra:', parquet)
\"
# Expected: \"pyarrow (>=7.0.0) ; extra == 'parquet'\".

# Restore.
git checkout origin/main -- pyproject.toml requirements.min.txt
\`\`\`

## What I ran locally

- \`pip install -e \".[dev]\"\` -> ok with pandas 3.0.2 + pyarrow 24
- \`pytest tests/stattests/ tests/calculations/\` -> 150 passed
- Confirmed via PyPI metadata that the \`parquet\` extra exists on pandas 2.0.0
  but not on 1.3.5 / 1.5.x.

## Edge cases

| Scenario | Before | After |
|---|---|---|
| Fresh install with python 3.10/3.11/3.12/3.13 | resolves to pandas 2.x anyway (no wheels for 1.3.5) — extra silently ignored | Resolves to pandas >=2.0.0 with the parquet extra correctly applied |
| \`pip install -r requirements.min.txt\` for the min-version CI job | Cannot install (no 1.3.5 wheel for current python; build fails) | Installs pandas 2.0.0 + pyarrow |
| Downstream user pinning pandas==1.5.x | The \`[parquet]\` extra was a no-op anyway — no behavioral difference | Now blocked at install time, matching declared support |

## AI disclosure

This pull request was authored with assistance from Anthropic's Claude (an AI
coding assistant) running under my direction. I verified the parquet-extra
introduction via PyPI metadata for both pandas 1.3.5 and 2.0.0.