### PR TITLE
fix(stattests): silence scipy>=1.17 anderson_ksamp midrank deprecation (#1534)

### DIFF
--- a/src/evidently/legacy/calculations/stattests/anderson_darling_stattest.py
+++ b/src/evidently/legacy/calculations/stattests/anderson_darling_stattest.py
@@ -26,11 +26,21 @@ Example:
 from typing import Tuple
 
 import pandas as pd
+import scipy
 from scipy.stats import anderson_ksamp
 
 from evidently.legacy.calculations.stattests.registry import StatTest
 from evidently.legacy.calculations.stattests.registry import register_stattest
 from evidently.legacy.core import ColumnType
+
+# scipy>=1.17 deprecates the `midrank` keyword in favour of `variant=`. When
+# `variant` is supplied the return object is no longer a 3-tuple and exposes
+# `pvalue` instead. Use the new API on scipy>=1.17 to silence the
+# DeprecationWarning reported in issue #1534, and fall back to the legacy
+# tuple shape on older scipy. The minimum supported scipy is 1.10 per
+# pyproject.toml, so the fallback path is required.
+_SCIPY_VERSION: Tuple[int, ...] = tuple(int(p) for p in scipy.__version__.split(".")[:2] if p.isdigit())
+_USE_VARIANT_KWARG = _SCIPY_VERSION >= (1, 17)
 
 
 def _anderson_darling(
@@ -39,7 +49,14 @@ def _anderson_darling(
     feature_type: ColumnType,
     threshold: float,
 ) -> Tuple[float, bool]:
-    p_value = anderson_ksamp([reference_data.values, current_data.values])[2]
+    samples = [reference_data.values, current_data.values]
+    if _USE_VARIANT_KWARG:
+        # New scipy API: returns a result object with a `.pvalue` attribute.
+        result = anderson_ksamp(samples, variant="midrank")
+        p_value = result.pvalue
+    else:
+        # Legacy 3-tuple: (statistic, critical_values, significance_level).
+        p_value = anderson_ksamp(samples)[2]
     return p_value, p_value < threshold
 
 

--- a/tests/stattests/test_stattests.py
+++ b/tests/stattests/test_stattests.py
@@ -110,6 +110,23 @@ def test_anderson_darling() -> None:
     assert anderson_darling_test.func(reference, current, "num", 0.001) == (approx(0.0635, abs=1e-3), False)
 
 
+def test_anderson_darling_no_scipy_deprecation_warning() -> None:
+    """Regression test for issue #1534: scipy>=1.17 deprecated the implicit
+    `midrank` default of anderson_ksamp. Calling the Evidently stat test
+    must not emit a DeprecationWarning about it."""
+    import warnings
+
+    reference = pd.Series([38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0])
+    current = pd.Series([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        anderson_darling_test.func(reference, current, "num", 0.001)
+    midrank_warnings = [w for w in caught if "midrank" in str(w.message) or "variant" in str(w.message)]
+    assert not midrank_warnings, (
+        "anderson_ksamp emitted a midrank/variant DeprecationWarning: " f"{[str(w.message) for w in midrank_warnings]}"
+    )
+
+
 def test_g_test() -> None:
     reference = pd.Series(["a", "b", "c"]).repeat([5, 5, 8])
     current = pd.Series(["a", "b", "c"]).repeat([4, 6, 8])


### PR DESCRIPTION
## Summary

Closes #1534.

scipy 1.17 deprecated the implicit \`midrank\` default of \`anderson_ksamp\` in
favour of an explicit \`variant=\` keyword. Calling
\`anderson_ksamp(samples)\` without \`variant=\` emits a \`DeprecationWarning\`
per call (visible in any test run, see the \"warnings summary\" section of
\`pytest tests/stattests/\` on \`origin/main\`):

> \`Parameter 'variant' has been introduced to replace 'midrank';
> 'midrank' will be removed in SciPy 1.19.0. Specify 'variant' to silence
> this warning. Note that the returned object will no longer be unpackable
> as a tuple, and 'critical_values' will be omitted.\`

Issue #1534 reports that this breaks user CI policies that promote
\`DeprecationWarning\` to errors.

## Fix

In \`src/evidently/legacy/calculations/stattests/anderson_darling_stattest.py\`:

* On scipy>=1.17, call \`anderson_ksamp(samples, variant=\"midrank\")\` — the
  string matches the legacy \`midrank=True\` default — and read the result
  object's \`.pvalue\` attribute.
* On older scipy (down to 1.10, the project's floor), keep the legacy
  3-tuple unpacking.

## Reproduce BEFORE/AFTER yourself (copy-paste)

\`\`\`bash
git fetch origin && git fetch https://github.com/jbbqqf/evidently.git fix/1534-scipy-anderson-deprecation:_pr1534
pip install -q -e \".[dev]\" >/dev/null

run_check() {
  python - <<'PY'
import warnings, pandas as pd
from evidently.legacy.calculations.stattests.anderson_darling_stattest import anderson_darling_test
ref = pd.Series([38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0])
cur = pd.Series([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter(\"always\")
    anderson_darling_test.func(ref, cur, \"num\", 0.001)
hits = [x for x in w if 'midrank' in str(x.message) or 'variant' in str(x.message)]
print(f\"midrank/variant warnings: {len(hits)}\")
for h in hits:
    print(\"  -\", h.category.__name__, str(h.message)[:120])
PY
}

# BEFORE — origin/main: scipy emits DeprecationWarning.
git checkout origin/main -- src/evidently/legacy/calculations/stattests/anderson_darling_stattest.py
run_check
# Expected (scipy>=1.17): 'midrank/variant warnings: 1' with the deprecation message.

# AFTER — this branch: silenced.
git checkout _pr1534 -- src/evidently/legacy/calculations/stattests/anderson_darling_stattest.py
run_check
# Expected: 'midrank/variant warnings: 0'.

# Restore.
git checkout origin/main -- src/evidently/legacy/calculations/stattests/anderson_darling_stattest.py
\`\`\`

## What I ran locally

- \`pytest tests/stattests -q\` -> 63 passed
- \`pytest tests/stattests/test_stattests.py::test_anderson_darling_no_scipy_deprecation_warning\`
  fails on \`origin/main\` (DeprecationWarning emitted), passes on this branch.
- \`ruff check\` and \`ruff format --check\` -> clean.

## Edge cases

| scipy version | Path taken | Numerical result |
|---|---|---|
| 1.17+ | \`variant=\"midrank\"\` + \`.pvalue\` | Same p-value as legacy midrank=True |
| 1.10 .. 1.16 | Legacy 3-tuple unpack | Unchanged |
| <1.10 | Below pyproject floor; not supported | n/a |

## AI disclosure

This pull request was authored with assistance from Anthropic's Claude (an AI
coding assistant) running under my direction. I verified the SciPy
deprecation message and the new return-shape contract via \`help(anderson_ksamp)\`
on scipy 1.17 before writing the patch.