### PR TITLE
fix(metrics): GroupBy(ValueDrift) widget keeps decorated display name (#1706)

### DIFF
--- a/src/evidently/metrics/column_statistics.py
+++ b/src/evidently/metrics/column_statistics.py
@@ -601,7 +601,18 @@ class ValueDriftCalculation(SingleValueCalculation[ValueDrift]):
         if self.metric.threshold is None:
             self.resolve_parameter("threshold", drift.stattest_threshold)
         result = self.result(drift.drift_score)
-        result.widget = self._render(drift, Options(), ColorOptions())
+        # Pass the GroupBy-decorated display_name through to the widget so the
+        # rendered widget title matches the metric label users see elsewhere.
+        # When this metric is not wrapped, _render keeps the historical
+        # "Drift in column 'X'" wording. See issue #1706 — without this,
+        # GroupBy(ValueDrift(...)) widgets always rendered the bare column
+        # name and lost the group/label suffix.
+        decorated_name = self.display_name()
+        # _GROUP_BY_MARKER is the suffix appended by GroupByMetricCalculation
+        # (see metrics/group_by.py). We only override the widget title when it
+        # is present, to keep behavior unchanged outside a GroupBy.
+        widget_title = decorated_name if " group by '" in decorated_name else None
+        result.widget = self._render(drift, Options(), ColorOptions(), display_name=widget_title)
         if self.metric.tests is None and context.configuration.include_tests:
             # todo: move to _default_tests
             result.set_tests(
@@ -627,7 +638,13 @@ class ValueDriftCalculation(SingleValueCalculation[ValueDrift]):
     def display_name(self) -> str:
         return f"Value drift for {self.metric.column}"
 
-    def _render(self, result: ColumnDataDriftMetrics, options, color_options):
+    def _render(
+        self,
+        result: ColumnDataDriftMetrics,
+        options,
+        color_options,
+        display_name: Optional[str] = None,
+    ):
         if result.drift_detected:
             drift = "detected"
 
@@ -720,6 +737,11 @@ class ValueDriftCalculation(SingleValueCalculation[ValueDrift]):
                     widget=reference_table_examples,
                 ),
             ]
+        # Use the caller-supplied display_name when present (e.g. GroupBy
+        # decorates it with " group by '<col>' for label: '<label>'"); fall
+        # back to the historical wording when called outside a GroupBy. See
+        # issue #1706.
+        title = display_name if display_name is not None else f"Drift in column '{result.column_name}'"
         render_result = [
             counter(
                 counters=[
@@ -729,7 +751,7 @@ class ValueDriftCalculation(SingleValueCalculation[ValueDrift]):
                             f"Drift detection method: {result.stattest_name}. "
                             f"Drift score: {drift_score}"
                         ),
-                        f"Drift in column '{result.column_name}'",
+                        title,
                     )
                 ],
                 title="",

--- a/tests/future/metrics/test_groupby_value_drift.py
+++ b/tests/future/metrics/test_groupby_value_drift.py
@@ -1,0 +1,66 @@
+"""Regression tests for issue #1706 — GroupBy(ValueDrift) display_name not
+shown properly. Before the fix the rendered widget for ValueDrift always
+read "Drift in column 'X'" even when wrapped in GroupBy, dropping the group
+column / label suffix."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from evidently.core.datasets import DataDefinition
+from evidently.core.datasets import Dataset
+from evidently.core.report import Report
+from evidently.metrics.column_statistics import ValueDrift
+from evidently.metrics.group_by import GroupBy
+
+
+def _build_datasets():
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "value": np.concatenate([rng.normal(size=100), rng.normal(loc=2, size=100)]),
+            "group": ["a"] * 100 + ["b"] * 100,
+        }
+    )
+    ref = Dataset.from_pandas(df, data_definition=DataDefinition())
+    cur = Dataset.from_pandas(df.copy(), data_definition=DataDefinition())
+    return cur, ref
+
+
+def _counter_titles_for(metrics):
+    """Run a report with the given metrics and return the list of counter
+    titles (i.e. the prominent header text on each ValueDrift widget)."""
+    cur, ref = _build_datasets()
+    snap = Report(metrics).run(cur, ref)
+    ctx = snap.context
+    titles: list[str] = []
+    for fp in snap.metric_results:
+        res = ctx.get_metric_result(fp)
+        widgets = res.widget if isinstance(res.widget, list) else [res.widget]
+        for w in widgets:
+            params = (w.dict() if hasattr(w, "dict") else w).get("params") or {}
+            for c in params.get("counters") or []:
+                # `value` is the header; `label` is the description text.
+                titles.append(c.get("value", ""))
+    return titles
+
+
+def test_groupby_value_drift_widget_uses_decorated_display_name() -> None:
+    """In a GroupBy(ValueDrift(...)) the rendered widget title must include
+    the group-by suffix (`group by '<col>' for label: '<label>'`)."""
+    titles = _counter_titles_for([GroupBy(ValueDrift(column="value"), "group")])
+    decorated = [t for t in titles if "group by 'group'" in t and "for label:" in t]
+    assert len(decorated) >= 2, (
+        "Expected the GroupBy decoration to appear in widget titles for both "
+        f"groups (a and b); got titles={titles!r}"
+    )
+
+
+def test_plain_value_drift_keeps_default_widget_title() -> None:
+    """Outside a GroupBy the widget keeps the historical 'Drift in column'
+    wording so this fix is not a regression for existing reports."""
+    titles = _counter_titles_for([ValueDrift(column="value")])
+    assert any(
+        "Drift in column 'value'" in t for t in titles
+    ), f"Plain ValueDrift must keep its historical widget title; got {titles!r}"


### PR DESCRIPTION
## Summary

Closes #1706.

\`ValueDriftCalculation._render\` hard-coded the widget title as
\`f\"Drift in column '{result.column_name}'\"\` (see
\`src/evidently/metrics/column_statistics.py\`). When the calculation is
wrapped in \`GroupBy(...)\`, \`GroupByMetricCalculation.calculate\` patches
\`self.calculation.display_name\` so that other metrics (MaxValue, MeanValue,
…) pick up the \"group by '\<col\>' for label: '\<label\>'\" suffix at render
time — they call \`self.display_name()\` from \`StatisticsCalculation.calculate\`.
ValueDrift never read the patched name, so its widget always rendered the
bare column name regardless of how it was wrapped, which is exactly the
bug reported in #1706.

## Fix

\`src/evidently/metrics/column_statistics.py\`:

* Pass the GroupBy-decorated \`display_name()\` through to \`_render\` only
  when it carries the GroupBy suffix (\`\" group by '\"\` substring). This
  preserves the historical \"Drift in column 'X'\" wording for non-GroupBy
  reports — no surprise behavior change for existing users.
* \`_render\` now accepts an optional \`display_name=\` argument and uses it as
  the counter header.

## Reproduce BEFORE/AFTER yourself (copy-paste)

\`\`\`bash
git fetch origin && git fetch https://github.com/jbbqqf/evidently.git fix/1706-groupby-valuedrift-display-name:_pr1706
pip install -q -e \".[dev]\" >/dev/null

run_check() {
  python - <<'PY'
import numpy as np, pandas as pd
from evidently.core.datasets import Dataset, DataDefinition
from evidently.core.report import Report
from evidently.metrics.column_statistics import ValueDrift
from evidently.metrics.group_by import GroupBy
rng = np.random.default_rng(0)
df = pd.DataFrame({
    \"value\": np.concatenate([rng.normal(size=100), rng.normal(loc=2, size=100)]),
    \"group\": [\"a\"]*100 + [\"b\"]*100,
})
ref = Dataset.from_pandas(df, data_definition=DataDefinition())
cur = Dataset.from_pandas(df.copy(), data_definition=DataDefinition())
snap = Report([GroupBy(ValueDrift(column=\"value\"), \"group\")]).run(cur, ref)
ctx = snap.context
for fp in snap.metric_results:
    res = ctx.get_metric_result(fp)
    widgets = res.widget if isinstance(res.widget, list) else [res.widget]
    for w in widgets:
        for c in (w.dict().get(\"params\") or {}).get(\"counters\") or []:
            print(\"widget title:\", c.get(\"value\"))
PY
}

# BEFORE — origin/main: every counter says 'Drift in column 'value'', no group/label suffix.
git checkout origin/main -- src/evidently/metrics/column_statistics.py
run_check
# Expected: 'widget title: Drift in column \\'value\\'' (twice).

# AFTER — this branch: each widget shows the GroupBy decoration.
git checkout _pr1706 -- src/evidently/metrics/column_statistics.py
run_check
# Expected: 'widget title: Value drift for value group by \\'group\\' for label: \\'a\\'' and same for label 'b'.

git checkout origin/main -- src/evidently/metrics/column_statistics.py
\`\`\`

## What I ran locally

- \`pytest tests/future/metrics tests/test_preset/test_data_drift_preset.py -q\` -> 1417 passed.
- \`pytest tests/future/metrics/test_groupby_value_drift.py\` -> 2 passed; on
  \`origin/main\` the GroupBy assertion fails with the bare \"Drift in column 'value'\"
  title.
- \`ruff check\` and \`ruff format --check\` -> clean.

## Edge cases

| Scenario | Before | After |
|---|---|---|
| Plain \`ValueDrift(column=\"x\")\` | \"Drift in column 'x'\" | unchanged |
| \`GroupBy(ValueDrift(column=\"x\"), \"g\")\` | \"Drift in column 'x'\" (bug) | \"Value drift for x group by 'g' for label: '\<label\>'\" |
| \`GroupBy(MaxValue(\"x\"), \"g\")\` (other metric) | already correct | unchanged |

## AI disclosure

This pull request was authored with assistance from Anthropic's Claude (an AI
coding assistant) running under my direction. I traced the patching mechanism
(\`metrics/group_by.py:_patched_display_name\`) and confirmed the fix matches
the convention StatisticsCalculation already uses.