### PR TITLE
Fix/1616 pd na in by label count

### DIFF
--- a/src/evidently/core/metric_types.py
+++ b/src/evidently/core/metric_types.py
@@ -486,6 +486,12 @@ class ByLabelCountValue(MetricResult):
     count_display_name_template: str = "Missing label {label} count"
     share_display_name_template: str = "Missing label {label} share"
 
+    @validator("counts", "shares", pre=True)
+    def _convert_label_keys(cls, value):
+        if not isinstance(value, dict):
+            return value
+        return {convert_types(k): v for k, v in value.items()}
+
     def labels(self) -> List[Label]:
         return list(self.counts.keys())
 
@@ -551,6 +557,8 @@ except:  # noqa: E722
 
 
 def convert_types(val):
+    if val is pd.NA:
+        return None
     if isinstance(
         val,
         (

--- a/src/evidently/metrics/column_statistics.py
+++ b/src/evidently/metrics/column_statistics.py
@@ -869,9 +869,9 @@ class UniqueValueCountCalculation(ByLabelCountCalculation[UniqueValueCount]):
         return f"Unique Value Share: {self.metric.column} for label {label}"
 
     def _all_unique_values(self, current: Dataset, reference: Optional[Dataset]) -> set:
-        values = set(current.as_dataframe()[self.metric.column].unique())
+        values = set(current.as_dataframe()[self.metric.column].dropna().unique())
         if reference is not None:
-            values.update(reference.as_dataframe()[self.metric.column].unique())
+            values.update(reference.as_dataframe()[self.metric.column].dropna().unique())
         return values
 
     def _calculate_value(self, dataset: Dataset, values: set):

--- a/tests/future/metrics/test_unique_value_count.py
+++ b/tests/future/metrics/test_unique_value_count.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pandas as pd
 
+from evidently import DataDefinition
 from evidently import Dataset
 from evidently import Report
 from evidently.core.metric_types import ByLabelCountValue
@@ -40,3 +42,37 @@ def test_unique_value_count_metric():
         assert label_count.display_name == result[label]["count_display_name"]
         assert label_share.value == result[label]["share"]
         assert label_share.display_name == result[label]["share_display_name"]
+
+
+def test_unique_value_count_with_pd_na_in_string_dtype():
+    """Issue #1616: pd.NA in a nullable-string column must not become a label key."""
+    metric = UniqueValueCount(column="col1")
+    data = pd.DataFrame({"col1": pd.Series(["a", "a", "b", pd.NA], dtype="string")})
+    dataset = Dataset.from_pandas(data, DataDefinition(categorical_columns=["col1"]))
+    res = Report([metric]).run(dataset, None)._context.get_metric_result(metric)
+    assert isinstance(res, ByLabelCountValue)
+    assert set(res.labels()) == {"a", "b"}
+    a_count, _ = res.get_label_result("a")
+    b_count, _ = res.get_label_result("b")
+    assert a_count.value == 2
+    assert b_count.value == 1
+
+
+def test_unique_value_count_with_nan_in_object_dtype():
+    """np.nan / None in an object column also must not surface as a label."""
+    metric = UniqueValueCount(column="col1")
+    data = pd.DataFrame({"col1": pd.Series(["a", "b", None, np.nan], dtype="object")})
+    dataset = Dataset.from_pandas(data, DataDefinition(categorical_columns=["col1"]))
+    res = Report([metric]).run(dataset, None)._context.get_metric_result(metric)
+    assert isinstance(res, ByLabelCountValue)
+    assert set(res.labels()) == {"a", "b"}
+
+
+def test_unique_value_count_with_pd_na_in_int64_dtype():
+    """pd.NA in a nullable Int64 column."""
+    metric = UniqueValueCount(column="col1")
+    data = pd.DataFrame({"col1": pd.array([1, 2, 2, pd.NA], dtype="Int64")})
+    dataset = Dataset.from_pandas(data, DataDefinition(categorical_columns=["col1"]))
+    res = Report([metric]).run(dataset, None)._context.get_metric_result(metric)
+    assert isinstance(res, ByLabelCountValue)
+    assert set(res.labels()) == {1, 2}

--- a/tests/future/presets/test_dataset_stats_na.py
+++ b/tests/future/presets/test_dataset_stats_na.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from evidently import DataDefinition
+from evidently import Dataset
+from evidently import Report
+from evidently.presets import DataDriftPreset
+from evidently.presets import DataSummaryPreset
+
+
+def _make_dataset() -> Dataset:
+    df = pd.DataFrame({"a": pd.Series(["x", "y", "z", pd.NA], dtype="string")})
+    return Dataset.from_pandas(df, DataDefinition(categorical_columns=["a"]))
+
+
+def test_data_summary_preset_handles_pd_na():
+    """Issue #1616: DataSummaryPreset must not fail on pd.NA in a categorical column."""
+    Report([DataSummaryPreset()]).run(current_data=_make_dataset())
+
+
+def test_data_drift_preset_handles_pd_na():
+    """Issue #1616: DataDriftPreset must not fail on pd.NA in a categorical column."""
+    Report([DataDriftPreset()]).run(current_data=_make_dataset(), reference_data=_make_dataset())

--- a/tests/future/test_metric_types.py
+++ b/tests/future/test_metric_types.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from evidently.core.metric_types import ByLabelCountValue
@@ -9,6 +10,8 @@ from evidently.core.metric_types import SingleValue
     "input,output",
     [
         ({np.nan: (1.0, 1.0)}, ({"nan": 1.0}, {"nan": 1.0})),
+        ({pd.NA: (1.0, 1.0)}, ({None: 1.0}, {None: 1.0})),
+        ({np.int64(7): (3.0, 0.5)}, ({7: 3.0}, {7: 0.5})),
     ],
 )
 def test_by_label_count_value(input: dict, output: tuple):


### PR DESCRIPTION
Fixes #1616.

## Description
`DataSummaryPreset` and `DataDriftPreset` crashed with a `pydantic.ValidationError` whenever a categorical column contained `pd.NA` — pandas' native missing-value sentinel for nullable dtypes (`string`, `Int64`, `boolean`, etc.). Users had to convert `pd.NA` to `None` before passing data in, defeating the point of running exploratory metrics on raw data.

This PR makes both presets handle `pd.NA` transparently. Missing values are treated as missing — counted by `MissingValueCount`, never surfaced as a phantom `<NA>` label in `ByLabelCountValue`. The fix is three small, layered changes (one direct cause + two defensive guards so the same class of bug can't quietly resurface in future `ByLabelCount` metrics). No public API changes; no `Label` type change.
```python
import pandas as pd
from evidently import DataDefinition, Dataset, Report
from evidently.presets import DataSummaryPreset

df = pd.DataFrame({"a": pd.Series(["x", "y", "z", pd.NA], dtype="string")})
ds = Dataset.from_pandas(df, DataDefinition(categorical_columns=["a"]))
Report([DataSummaryPreset()]).run(current_data=ds)
# Before: pydantic.ValidationError on ByLabelCountValue (counts/shares __key__)
# After:  runs cleanly; pd.NA is treated as missing, not as a label.
```

The same failure hit `DataDriftPreset`. Both presets now pass.

## Root cause

Three cooperating defects:

1. **`UniqueValueCountCalculation._all_unique_values`** used `pd.Series.unique()`, which preserves `pd.NA` / `np.nan`. The NA sentinel was then carried into the result dict as a label key.
2. **`ByLabelCountValue`** lacked the `@validator(..., pre=True)` key-coercion that its sibling `ByLabelValue` has, so non-`Label`-typed dict keys (e.g. `np.int64`, `pd.NA`) reached pydantic uncoerced.
3. **`convert_types`** relied on `np.isnan(val)`, which raises `TypeError: boolean value of NA is ambiguous` on `pd.NA`.

## Changes

- **`src/evidently/metrics/column_statistics.py`** — `UniqueValueCountCalculation._all_unique_values` now calls `.dropna().unique()`, aligning the unique-value set with the existing `value_counts(dropna=True)` on the count side. Missing values continue to be reported separately by `MissingValueCount` (no double-counting).
- **`src/evidently/core/metric_types.py`**
  - Add `@validator("counts", "shares", pre=True)` on `ByLabelCountValue`, mirroring `ByLabelValue.convert_labels`.
  - Identity-check `pd.NA` in `convert_types` and normalize to `None`, consistent with `Label = Union[StrictBool, int, str, None]`. `np.nan` behavior is preserved (still falls through to pydantic's str-coercion path, matching the existing test contract).

## Tests

- **New** `tests/future/presets/test_dataset_stats_na.py` — end-to-end coverage matching the issue's exact reproduction on both `DataSummaryPreset` and `DataDriftPreset`.
- **Extended** `tests/future/metrics/test_unique_value_count.py` — cases for `pd.NA` in `string` / `object` / `Int64` dtypes.
- **Extended** `tests/future/test_metric_types.py` — parametrize cases covering `pd.NA` and `np.int64` keys on `ByLabelCountValue`.
